### PR TITLE
Add WhatsApp-like messaging feature (Viestit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,81 @@ export class MapComponent {
 - ✅ Components stay focused on orchestration
 - ✅ Clear separation of concerns
 
+### 7. Property Access and Performance
+
+#### Private vs Public Properties
+- Mark properties as `private` if they are NOT used in the template
+- Only expose properties that the template needs
+
+```typescript
+// ✅ Good: Private property not used in template
+export class MyComponent {
+  private readonly service = inject(MyService);  // Not in template
+
+  items$ = this.service.getItems();  // Used in template (public)
+}
+
+// ❌ Bad: Public property not used in template
+export class MyComponent {
+  readonly service = inject(MyService);  // Should be private
+}
+```
+
+#### Readonly Properties over Getters
+- Use `readonly` properties instead of `get` accessors for computed values that don't change
+- Getters are re-evaluated on every change detection cycle, causing performance issues
+
+```typescript
+// ✅ Good: Readonly property (computed once)
+export class ConversationCardComponent {
+  @Input() conversation!: Conversation;
+
+  // These are set once in ngOnChanges or via Input transform
+  readonly displayInfo = computed(() => getConversationDisplayInfo(this.conversation));
+}
+
+// ❌ Bad: Getter (re-evaluated on every change detection)
+export class ConversationCardComponent {
+  @Input() conversation!: Conversation;
+
+  get icon(): string {
+    return this.conversation.displayInfo.icon;  // Called many times!
+  }
+
+  get title(): string {
+    return this.conversation.displayInfo.title;  // Called many times!
+  }
+}
+```
+
+**When getters ARE acceptable:**
+- Simple property access that's truly trivial (e.g., `get isEmpty() { return this.items.length === 0; }`)
+- When the value MUST be re-computed on each access (rare)
+
+**Preferred alternatives to getters:**
+1. **Direct template access**: `{{ conversation.displayInfo.title }}` instead of `{{ title }}`
+2. **Computed values in vm$**: Include computed values in the ViewModel
+3. **ngOnChanges**: Compute values when inputs change
+4. **Angular Signals**: Use `computed()` for reactive derived values
+
+```typescript
+// ✅ Best: Access directly in template
+// Template: {{ conversation.displayInfo.title }}
+
+// ✅ Good: Compute in ngOnChanges
+export class ConversationCardComponent implements OnChanges {
+  @Input() conversation!: ConversationWithDisplay;
+
+  displayTitle = '';
+  displaySubtitle = '';
+
+  ngOnChanges(): void {
+    this.displayTitle = this.conversation.displayInfo.title;
+    this.displaySubtitle = this.conversation.displayInfo.subtitle ?? '';
+  }
+}
+```
+
 ### Summary Checklist
 - [ ] Use `inject()` instead of constructor injection
 - [ ] Expose observables with `async` pipe (avoid manual subscriptions)
@@ -393,8 +468,11 @@ export class MapComponent {
 - [ ] Follow component structure: Properties → vm$ → Public → Lifecycle → Private
 - [ ] Use alphabetical ordering within each section
 - [ ] Extract logic to pure helper functions with unit tests
+- [ ] Mark properties `private` if not used in template
+- [ ] Use `readonly` properties over `get` accessors for performance
+- [ ] Access Input properties directly in templates when possible
 
-### 7. Unit Testing for Helper Functions
+### 8. Unit Testing for Helper Functions
 
 **IMPORTANT**: All helper functions in `src/app/shared/utils/` MUST have corresponding unit tests.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ export class PlaytimeDialogComponent {
 Extract complex logic into **pure helper functions** in separate files instead of private methods. These helpers should:
 - Be **pure functions** (same input → same output, no side effects)
 - Live in `src/app/shared/utils/` or feature-specific `helpers/` folders
-- Have **unit tests**
+- Have **unit tests** (see Unit Testing section below)
 
 ```typescript
 // ✅ Good: Pure helper function (testable)
@@ -393,6 +393,56 @@ export class MapComponent {
 - [ ] Follow component structure: Properties → vm$ → Public → Lifecycle → Private
 - [ ] Use alphabetical ordering within each section
 - [ ] Extract logic to pure helper functions with unit tests
+
+### 7. Unit Testing for Helper Functions
+
+**IMPORTANT**: All helper functions in `src/app/shared/utils/` MUST have corresponding unit tests.
+
+**Naming convention:**
+- Helper file: `my-helper.ts` or `my.helper.ts`
+- Test file: `my-helper.spec.ts` or `my.helper.spec.ts` (same name with `.spec.ts` suffix)
+
+**Test file structure:**
+```typescript
+// src/app/shared/utils/my-helper.spec.ts
+import { myFunction, anotherFunction } from './my-helper';
+
+describe('My Helper', () => {
+  describe('myFunction', () => {
+    it('should handle normal input', () => {
+      expect(myFunction('input')).toBe('expected');
+    });
+
+    it('should handle edge cases', () => {
+      expect(myFunction('')).toBe('');
+      expect(myFunction(null as any)).toBeNull();
+    });
+  });
+
+  describe('anotherFunction', () => {
+    // Tests for another function...
+  });
+});
+```
+
+**What to test:**
+- ✅ Normal/happy path scenarios
+- ✅ Edge cases (empty strings, null, undefined, empty arrays)
+- ✅ Boundary conditions (min/max values)
+- ✅ Error conditions (invalid input)
+- ✅ All exported functions
+
+**Running tests:**
+```bash
+npm test                    # Run all tests
+npm test -- --watch         # Watch mode
+npm test -- --include=**/utils/**  # Run only utils tests
+```
+
+**Examples of existing tests:**
+- [string-array.helper.spec.ts](src/app/shared/utils/string-array.helper.spec.ts) - Array comparison helpers
+- [conversation.helpers.spec.ts](src/app/shared/utils/conversation.helpers.spec.ts) - Conversation sorting and display
+- [message-format.helper.spec.ts](src/app/shared/utils/message-format.helper.spec.ts) - Message formatting
 
 ## Development
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
 import { profileCompletionGuard } from './core/guards/profile-completion.guard';
 
 export const routes: Routes = [
@@ -35,5 +36,15 @@ export const routes: Routes = [
   {
     path: 'profile',
     loadComponent: () => import('./core/user/user-profile/user-profile.component').then(m => m.UserProfileComponent)
+  },
+  {
+    path: 'messages',
+    loadComponent: () => import('./features/messages/messages-page/messages-page.component').then(m => m.MessagesPageComponent),
+    canActivate: [authGuard]
+  },
+  {
+    path: 'messages/:conversationId',
+    loadComponent: () => import('./features/messages/conversation-detail-page/conversation-detail-page.component').then(m => m.ConversationDetailPageComponent),
+    canActivate: [authGuard]
   }
 ];

--- a/src/app/core/layout/header/header.component.html
+++ b/src/app/core/layout/header/header.component.html
@@ -34,6 +34,13 @@
                   <span>Profiili</span>
                 </span>
               </a>
+              <a mat-menu-item [routerLink]="['/messages']">
+                <span class="menu-item-content">
+                  <mat-icon>mail</mat-icon>
+                  <span>Viestit</span>
+                </span>
+              </a>
+              <mat-divider></mat-divider>
               <button mat-menu-item (click)="onLogout()">
                 <span class="menu-item-content">
                   <mat-icon>logout</mat-icon>

--- a/src/app/core/layout/header/header.component.ts
+++ b/src/app/core/layout/header/header.component.ts
@@ -5,6 +5,7 @@ import { combineLatest, map } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MapStateService } from '../../../core/services/map-state.service';
 import { SupabaseService } from '../../../shared/services/supabase.service';
@@ -14,7 +15,7 @@ import { AuthProviderDialogComponent } from '../../auth/auth-provider-dialog/aut
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatButtonModule, MatIconModule, MatMenuModule, MatDialogModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, MatDividerModule, MatIconModule, MatMenuModule, MatDialogModule],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })

--- a/src/app/features/messages/conversation-card/conversation-card.component.html
+++ b/src/app/features/messages/conversation-card/conversation-card.component.html
@@ -1,0 +1,27 @@
+<div
+  class="conversation-card"
+  [class.unread]="hasUnread"
+  [class.selected]="isSelected"
+  role="button"
+  tabindex="0"
+>
+  <div class="card-icon">
+    <mat-icon>{{ icon }}</mat-icon>
+  </div>
+
+  <div class="card-content">
+    <div class="card-header">
+      <span class="title">{{ title }}</span>
+      <span class="timestamp">{{ timestamp }}</span>
+    </div>
+
+    <div class="card-preview">
+      <span class="subtitle" *ngIf="subtitle">{{ subtitle }}: </span>
+      <span class="last-message">{{ lastMessagePreview }}</span>
+    </div>
+  </div>
+
+  <div class="unread-badge" *ngIf="hasUnread">
+    {{ unreadCount > 99 ? '99+' : unreadCount }}
+  </div>
+</div>

--- a/src/app/features/messages/conversation-card/conversation-card.component.html
+++ b/src/app/features/messages/conversation-card/conversation-card.component.html
@@ -1,27 +1,33 @@
-<div
-  class="conversation-card"
-  [class.unread]="conversation.hasUnread"
-  [class.selected]="isSelected"
-  role="button"
-  tabindex="0"
->
-  <div class="card-icon">
-    <mat-icon>{{ conversation.displayInfo.icon }}</mat-icon>
-  </div>
+<mat-card class="conversation-card" [class.unread]="conversation.hasUnread">
+  <mat-card-header>
+    <div class="card-header-content">
+      <div class="conversation-info">
+        <h3 class="title">{{ conversation.displayInfo.title }}</h3>
+        <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}</span>
+      </div>
+      <div class="status-wrapper">
+        <div class="meta-row">
+          <mat-icon class="meta-icon">schedule</mat-icon>
+          <span class="meta-text">{{ timestamp }}</span>
+        </div>
+        <div class="unread-badge" *ngIf="conversation.hasUnread">
+          {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }} uutta
+        </div>
+      </div>
+    </div>
+  </mat-card-header>
 
-  <div class="card-content">
-    <div class="card-header">
-      <span class="title">{{ conversation.displayInfo.title }}</span>
-      <span class="timestamp">{{ timestamp }}</span>
+  <mat-card-content>
+    <div class="context-section" *ngIf="conversation.displayInfo.subtitle">
+      <mat-icon class="context-icon">{{ conversation.displayInfo.icon }}</mat-icon>
+      <span class="context-text">{{ conversation.displayInfo.subtitle }}</span>
     </div>
 
-    <div class="card-preview">
-      <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}: </span>
-      <span class="last-message">{{ lastMessagePreview }}</span>
-    </div>
-  </div>
-
-  <div class="unread-badge" *ngIf="conversation.hasUnread">
-    {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }}
-  </div>
-</div>
+    <p class="last-message" *ngIf="lastMessagePreview">
+      {{ lastMessagePreview }}
+    </p>
+    <p class="no-messages" *ngIf="!lastMessagePreview">
+      Aloita keskustelu
+    </p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/features/messages/conversation-card/conversation-card.component.html
+++ b/src/app/features/messages/conversation-card/conversation-card.component.html
@@ -1,33 +1,27 @@
-<mat-card class="conversation-card" [class.unread]="conversation.hasUnread">
-  <mat-card-header>
-    <div class="card-header-content">
-      <div class="conversation-info">
-        <h3 class="title">{{ conversation.displayInfo.title }}</h3>
-        <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}</span>
-      </div>
-      <div class="status-wrapper">
-        <div class="meta-row">
-          <mat-icon class="meta-icon">schedule</mat-icon>
-          <span class="meta-text">{{ timestamp }}</span>
-        </div>
-        <div class="unread-badge" *ngIf="conversation.hasUnread">
-          {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }} uutta
-        </div>
-      </div>
-    </div>
-  </mat-card-header>
+<div
+  class="conversation-item"
+  [class.unread]="conversation.hasUnread"
+  [class.selected]="isSelected"
+  role="button"
+  tabindex="0"
+>
+  <div class="item-icon">
+    <mat-icon>{{ conversation.displayInfo.icon }}</mat-icon>
+  </div>
 
-  <mat-card-content>
-    <div class="context-section" *ngIf="conversation.displayInfo.subtitle">
-      <mat-icon class="context-icon">{{ conversation.displayInfo.icon }}</mat-icon>
-      <span class="context-text">{{ conversation.displayInfo.subtitle }}</span>
+  <div class="item-content">
+    <div class="item-header">
+      <span class="title">{{ conversation.displayInfo.title }}</span>
+      <span class="timestamp">{{ timestamp }}</span>
     </div>
 
-    <p class="last-message" *ngIf="lastMessagePreview">
-      {{ lastMessagePreview }}
-    </p>
-    <p class="no-messages" *ngIf="!lastMessagePreview">
-      Aloita keskustelu
-    </p>
-  </mat-card-content>
-</mat-card>
+    <div class="item-preview">
+      <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}: </span>
+      <span class="last-message">{{ lastMessagePreview || 'Aloita keskustelu' }}</span>
+    </div>
+  </div>
+
+  <div class="unread-badge" *ngIf="conversation.hasUnread">
+    {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }}
+  </div>
+</div>

--- a/src/app/features/messages/conversation-card/conversation-card.component.html
+++ b/src/app/features/messages/conversation-card/conversation-card.component.html
@@ -1,27 +1,27 @@
 <div
   class="conversation-card"
-  [class.unread]="hasUnread"
+  [class.unread]="conversation.hasUnread"
   [class.selected]="isSelected"
   role="button"
   tabindex="0"
 >
   <div class="card-icon">
-    <mat-icon>{{ icon }}</mat-icon>
+    <mat-icon>{{ conversation.displayInfo.icon }}</mat-icon>
   </div>
 
   <div class="card-content">
     <div class="card-header">
-      <span class="title">{{ title }}</span>
+      <span class="title">{{ conversation.displayInfo.title }}</span>
       <span class="timestamp">{{ timestamp }}</span>
     </div>
 
     <div class="card-preview">
-      <span class="subtitle" *ngIf="subtitle">{{ subtitle }}: </span>
+      <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}: </span>
       <span class="last-message">{{ lastMessagePreview }}</span>
     </div>
   </div>
 
-  <div class="unread-badge" *ngIf="hasUnread">
-    {{ unreadCount > 99 ? '99+' : unreadCount }}
+  <div class="unread-badge" *ngIf="conversation.hasUnread">
+    {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }}
   </div>
 </div>

--- a/src/app/features/messages/conversation-card/conversation-card.component.scss
+++ b/src/app/features/messages/conversation-card/conversation-card.component.scss
@@ -1,120 +1,116 @@
-.conversation-card {
-  transition: all 0.3s ease;
-  background-color: #fafafa;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  border: 1px solid #e0e0e0;
+.conversation-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
   cursor: pointer;
+  transition: background-color 0.15s ease;
+  border-bottom: 1px solid #f0f0f0;
 
   &:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
-    transform: translateY(-2px);
+    background-color: #f5f5f5;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #4caf50;
+    outline-offset: -2px;
+  }
+
+  &.selected {
+    background-color: #e8f5e9;
   }
 
   &.unread {
-    border-left: 4px solid #4caf50;
     background-color: rgba(76, 175, 80, 0.05);
+
+    .title {
+      font-weight: 600;
+    }
+
+    .last-message {
+      font-weight: 500;
+      color: #333;
+    }
   }
 }
 
-.card-header-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  width: 100%;
-  gap: 0.75rem;
-}
-
-.conversation-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  flex: 1;
-
-  .title {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #4caf50;
-  }
-
-  .subtitle {
-    font-size: 0.875rem;
-    color: rgba(0, 0, 0, 0.6);
-  }
-}
-
-.status-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.25rem;
-}
-
-.meta-row {
+.item-icon {
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background-color: #e8f5e9;
+  flex-shrink: 0;
+
+  mat-icon {
+    color: #4caf50;
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+.item-content {
+  flex: 1;
+  min-width: 0; // Allow text truncation
+  display: flex;
+  flex-direction: column;
   gap: 0.25rem;
 }
 
-.meta-icon {
-  font-size: 0.875rem;
-  width: 0.875rem;
-  height: 0.875rem;
-  color: rgba(0, 0, 0, 0.5);
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
 }
 
-.meta-text {
-  font-size: 0.75rem;
-  color: rgba(0, 0, 0, 0.6);
+.title {
+  font-size: 0.9375rem;
+  font-weight: 400;
+  color: #333;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: #888;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.item-preview {
+  font-size: 0.8125rem;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subtitle {
+  color: #4caf50;
+  font-weight: 500;
+}
+
+.last-message {
+  color: #666;
 }
 
 .unread-badge {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.75rem;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  border-radius: 0.625rem;
   background-color: #4caf50;
   color: #fff;
   font-size: 0.6875rem;
   font-weight: 600;
-}
-
-mat-card-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding-top: 1rem;
-}
-
-.context-section {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-
-  .context-icon {
-    font-size: 1.25rem;
-    width: 1.25rem;
-    height: 1.25rem;
-    color: #4caf50;
-  }
-
-  .context-text {
-    font-size: 0.875rem;
-    color: rgba(0, 0, 0, 0.7);
-  }
-}
-
-.last-message {
-  margin: 0;
-  line-height: 1.6;
-  color: rgba(0, 0, 0, 0.87);
-  font-size: 0.875rem;
-}
-
-.no-messages {
-  margin: 0;
-  color: rgba(0, 0, 0, 0.5);
-  font-style: italic;
-  font-size: 0.875rem;
+  flex-shrink: 0;
 }

--- a/src/app/features/messages/conversation-card/conversation-card.component.scss
+++ b/src/app/features/messages/conversation-card/conversation-card.component.scss
@@ -1,115 +1,120 @@
 .conversation-card {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
+  transition: all 0.3s ease;
+  background-color: #fafafa;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  border: 1px solid #e0e0e0;
   cursor: pointer;
-  transition: background-color 0.15s ease;
-  border-bottom: 1px solid #f0f0f0;
 
   &:hover {
-    background-color: #f5f5f5;
-  }
-
-  &:focus-visible {
-    outline: 2px solid #4caf50;
-    outline-offset: -2px;
-  }
-
-  &.selected {
-    background-color: #e8f5e9;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+    transform: translateY(-2px);
   }
 
   &.unread {
+    border-left: 4px solid #4caf50;
     background-color: rgba(76, 175, 80, 0.05);
-
-    .title {
-      font-weight: 600;
-    }
-
-    .last-message {
-      font-weight: 600;
-      color: #333;
-    }
   }
 }
 
-.card-icon {
+.card-header-content {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  background-color: #e8f5e9;
-  flex-shrink: 0;
-
-  mat-icon {
-    color: #4caf50;
-    font-size: 1.25rem;
-    width: 1.25rem;
-    height: 1.25rem;
-  }
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+  gap: 0.75rem;
 }
 
-.card-content {
-  flex: 1;
-  min-width: 0; // Allow text truncation
+.conversation-info {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  flex: 1;
+
+  .title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #4caf50;
+  }
+
+  .subtitle {
+    font-size: 0.875rem;
+    color: rgba(0, 0, 0, 0.6);
+  }
 }
 
-.card-header {
+.status-wrapper {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
 }
 
-.title {
-  font-size: 0.9375rem;
-  font-weight: 400;
-  color: #333;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
-.timestamp {
+.meta-icon {
+  font-size: 0.875rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.meta-text {
   font-size: 0.75rem;
-  color: #888;
+  color: rgba(0, 0, 0, 0.6);
   white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.card-preview {
-  font-size: 0.8125rem;
-  color: #666;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.subtitle {
-  color: #888;
-}
-
-.last-message {
-  color: #666;
 }
 
 .unread-badge {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-width: 1.25rem;
-  height: 1.25rem;
-  padding: 0 0.375rem;
-  border-radius: 0.625rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.75rem;
   background-color: #4caf50;
   color: #fff;
   font-size: 0.6875rem;
   font-weight: 600;
-  flex-shrink: 0;
+}
+
+mat-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 1rem;
+}
+
+.context-section {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  .context-icon {
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #4caf50;
+  }
+
+  .context-text {
+    font-size: 0.875rem;
+    color: rgba(0, 0, 0, 0.7);
+  }
+}
+
+.last-message {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 0.875rem;
+}
+
+.no-messages {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.5);
+  font-style: italic;
+  font-size: 0.875rem;
 }

--- a/src/app/features/messages/conversation-card/conversation-card.component.scss
+++ b/src/app/features/messages/conversation-card/conversation-card.component.scss
@@ -1,0 +1,115 @@
+.conversation-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  border-bottom: 1px solid #f0f0f0;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #4caf50;
+    outline-offset: -2px;
+  }
+
+  &.selected {
+    background-color: #e8f5e9;
+  }
+
+  &.unread {
+    background-color: rgba(76, 175, 80, 0.05);
+
+    .title {
+      font-weight: 600;
+    }
+
+    .last-message {
+      font-weight: 600;
+      color: #333;
+    }
+  }
+}
+
+.card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: #e8f5e9;
+  flex-shrink: 0;
+
+  mat-icon {
+    color: #4caf50;
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+.card-content {
+  flex: 1;
+  min-width: 0; // Allow text truncation
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.title {
+  font-size: 0.9375rem;
+  font-weight: 400;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: #888;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.card-preview {
+  font-size: 0.8125rem;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subtitle {
+  color: #888;
+}
+
+.last-message {
+  color: #666;
+}
+
+.unread-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  border-radius: 0.625rem;
+  background-color: #4caf50;
+  color: #fff;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}

--- a/src/app/features/messages/conversation-card/conversation-card.component.ts
+++ b/src/app/features/messages/conversation-card/conversation-card.component.ts
@@ -1,11 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 
 import { ConversationWithDisplay } from '../messages-page/messages-page.component';
-import {
-  formatConversationTimestamp,
-} from '../../../shared/utils/conversation.helpers';
+import { formatConversationTimestamp } from '../../../shared/utils/conversation.helpers';
 import { truncateMessage } from '../../../shared/utils/message-format.helper';
 
 @Component({
@@ -15,41 +13,21 @@ import { truncateMessage } from '../../../shared/utils/message-format.helper';
   templateUrl: './conversation-card.component.html',
   styleUrl: './conversation-card.component.scss',
 })
-export class ConversationCardComponent {
+export class ConversationCardComponent implements OnChanges {
   @Input() conversation!: ConversationWithDisplay;
   @Input() isSelected = false;
 
-  get icon(): string {
-    return this.conversation.displayInfo.icon;
-  }
+  // Computed values (set in ngOnChanges to avoid getter performance issues)
+  lastMessagePreview = '';
+  timestamp = '';
 
-  get title(): string {
-    return this.conversation.displayInfo.title;
-  }
+  ngOnChanges(): void {
+    this.lastMessagePreview = this.conversation.lastMessage
+      ? truncateMessage(this.conversation.lastMessage.content, 50)
+      : 'Aloita keskustelu';
 
-  get subtitle(): string | undefined {
-    return this.conversation.displayInfo.subtitle;
-  }
-
-  get lastMessagePreview(): string {
-    if (!this.conversation.lastMessage) {
-      return 'Aloita keskustelu';
-    }
-    return truncateMessage(this.conversation.lastMessage.content, 50);
-  }
-
-  get timestamp(): string {
-    if (!this.conversation.lastMessage) {
-      return formatConversationTimestamp(this.conversation.createdAt);
-    }
-    return formatConversationTimestamp(this.conversation.lastMessage.createdAt);
-  }
-
-  get hasUnread(): boolean {
-    return this.conversation.hasUnread;
-  }
-
-  get unreadCount(): number {
-    return this.conversation.unreadCount;
+    this.timestamp = formatConversationTimestamp(
+      this.conversation.lastMessage?.createdAt ?? this.conversation.createdAt
+    );
   }
 }

--- a/src/app/features/messages/conversation-card/conversation-card.component.ts
+++ b/src/app/features/messages/conversation-card/conversation-card.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+import { ConversationWithDisplay } from '../messages-page/messages-page.component';
+import {
+  formatConversationTimestamp,
+} from '../../../shared/utils/conversation.helpers';
+import { truncateMessage } from '../../../shared/utils/message-format.helper';
+
+@Component({
+  selector: 'app-conversation-card',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './conversation-card.component.html',
+  styleUrl: './conversation-card.component.scss',
+})
+export class ConversationCardComponent {
+  @Input() conversation!: ConversationWithDisplay;
+  @Input() isSelected = false;
+
+  get icon(): string {
+    return this.conversation.displayInfo.icon;
+  }
+
+  get title(): string {
+    return this.conversation.displayInfo.title;
+  }
+
+  get subtitle(): string | undefined {
+    return this.conversation.displayInfo.subtitle;
+  }
+
+  get lastMessagePreview(): string {
+    if (!this.conversation.lastMessage) {
+      return 'Aloita keskustelu';
+    }
+    return truncateMessage(this.conversation.lastMessage.content, 50);
+  }
+
+  get timestamp(): string {
+    if (!this.conversation.lastMessage) {
+      return formatConversationTimestamp(this.conversation.createdAt);
+    }
+    return formatConversationTimestamp(this.conversation.lastMessage.createdAt);
+  }
+
+  get hasUnread(): boolean {
+    return this.conversation.hasUnread;
+  }
+
+  get unreadCount(): number {
+    return this.conversation.unreadCount;
+  }
+}

--- a/src/app/features/messages/conversation-card/conversation-card.component.ts
+++ b/src/app/features/messages/conversation-card/conversation-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 
 import { ConversationWithDisplay } from '../messages-page/messages-page.component';
@@ -9,7 +10,7 @@ import { truncateMessage } from '../../../shared/utils/message-format.helper';
 @Component({
   selector: 'app-conversation-card',
   standalone: true,
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatCardModule, MatIconModule],
   templateUrl: './conversation-card.component.html',
   styleUrl: './conversation-card.component.scss',
 })
@@ -23,8 +24,8 @@ export class ConversationCardComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.lastMessagePreview = this.conversation.lastMessage
-      ? truncateMessage(this.conversation.lastMessage.content, 50)
-      : 'Aloita keskustelu';
+      ? truncateMessage(this.conversation.lastMessage.content, 80)
+      : '';
 
     this.timestamp = formatConversationTimestamp(
       this.conversation.lastMessage?.createdAt ?? this.conversation.createdAt

--- a/src/app/features/messages/conversation-card/conversation-card.component.ts
+++ b/src/app/features/messages/conversation-card/conversation-card.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 
 import { ConversationWithDisplay } from '../messages-page/messages-page.component';
@@ -10,7 +9,7 @@ import { truncateMessage } from '../../../shared/utils/message-format.helper';
 @Component({
   selector: 'app-conversation-card',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatIconModule],
+  imports: [CommonModule, MatIconModule],
   templateUrl: './conversation-card.component.html',
   styleUrl: './conversation-card.component.scss',
 })

--- a/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.html
+++ b/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.html
@@ -1,0 +1,33 @@
+<ng-container *ngIf="vm$ | async as vm">
+  <div class="conversation-detail-page">
+    <!-- Loading state -->
+    <div class="loading-container" *ngIf="vm.loading">
+      <mat-spinner diameter="40"></mat-spinner>
+      <span>Ladataan viestejä...</span>
+    </div>
+
+    <ng-container *ngIf="!vm.loading && vm.conversation">
+      <app-conversation-header
+        [conversation]="vm.conversation"
+        [showBackButton]="true"
+        (backClicked)="onBackToList()"
+      ></app-conversation-header>
+
+      <app-message-thread
+        [messages]="vm.messages"
+        [currentUserId]="vm.currentUserId"
+      ></app-message-thread>
+
+      <app-message-input
+        (messageSent)="onMessageSent(vm.conversation.id, $event)"
+      ></app-message-input>
+    </ng-container>
+
+    <!-- Error state -->
+    <div class="error-state" *ngIf="!vm.loading && !vm.conversation">
+      <span class="material-icons">error_outline</span>
+      <p>Keskustelua ei löytynyt</p>
+      <button (click)="onBackToList()">Takaisin</button>
+    </div>
+  </div>
+</ng-container>

--- a/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.scss
+++ b/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.scss
@@ -1,0 +1,52 @@
+.conversation-detail-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 4rem); // Account for header
+  background-color: #fff;
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 1rem;
+  color: #666;
+}
+
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 1rem;
+  text-align: center;
+  color: #666;
+
+  .material-icons {
+    font-size: 3rem;
+    color: #ccc;
+  }
+
+  p {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  button {
+    padding: 0.5rem 1.5rem;
+    border: none;
+    border-radius: 0.25rem;
+    background-color: #4caf50;
+    color: #fff;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background-color: #43a047;
+    }
+  }
+}

--- a/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.ts
+++ b/src/app/features/messages/conversation-detail-page/conversation-detail-page.component.ts
@@ -1,0 +1,111 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, combineLatest, map, switchMap, of, filter } from 'rxjs';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { MessageService } from '../../../shared/services/message.service';
+import { UserService } from '../../../core/services/user.service';
+import { Conversation, Message } from '../../../shared/models/message.model';
+import { getConversationDisplayInfo, ConversationDisplayInfo } from '../../../shared/utils/conversation.helpers';
+
+import { ConversationHeaderComponent } from '../conversation-header/conversation-header.component';
+import { MessageThreadComponent } from '../message-thread/message-thread.component';
+import { MessageInputComponent } from '../message-input/message-input.component';
+
+export interface ConversationDetailWithDisplay extends Conversation {
+  displayInfo: ConversationDisplayInfo;
+}
+
+@Component({
+  selector: 'app-conversation-detail-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatProgressSpinnerModule,
+    ConversationHeaderComponent,
+    MessageThreadComponent,
+    MessageInputComponent,
+  ],
+  templateUrl: './conversation-detail-page.component.html',
+  styleUrl: './conversation-detail-page.component.scss',
+})
+export class ConversationDetailPageComponent implements OnInit {
+  private readonly messageService = inject(MessageService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  private loading$ = new BehaviorSubject<boolean>(true);
+  private messages$ = new BehaviorSubject<Message[]>([]);
+
+  vm$ = combineLatest({
+    params: this.route.params,
+    currentUser: this.userService.currentUser$,
+    loading: this.loading$,
+    messages: this.messages$,
+  }).pipe(
+    switchMap(({ params, currentUser, loading, messages }) => {
+      const conversationId = params['conversationId'];
+      const currentUserId = currentUser?.id;
+
+      if (!conversationId) {
+        return of({
+          conversation: null,
+          messages: [],
+          currentUserId,
+          loading: false,
+        });
+      }
+
+      return this.messageService.getConversation(conversationId).pipe(
+        map((conversation) => ({
+          conversation: {
+            ...conversation,
+            displayInfo: getConversationDisplayInfo(conversation, currentUserId),
+          } as ConversationDetailWithDisplay,
+          messages,
+          currentUserId,
+          loading,
+        }))
+      );
+    })
+  );
+
+  ngOnInit(): void {
+    this.route.params
+      .pipe(
+        filter((params) => !!params['conversationId']),
+        switchMap((params) => {
+          this.loading$.next(true);
+          const conversationId = params['conversationId'];
+
+          // Mark as read and load messages
+          this.messageService.markAsRead(conversationId).subscribe();
+
+          return this.messageService.getMessages(conversationId);
+        })
+      )
+      .subscribe({
+        next: (messages) => {
+          this.messages$.next(messages);
+          this.loading$.next(false);
+        },
+        error: () => this.loading$.next(false),
+      });
+  }
+
+  onBackToList(): void {
+    this.router.navigate(['/messages']);
+  }
+
+  onMessageSent(conversationId: string, content: string): void {
+    this.messageService.sendMessage(conversationId, { content }).subscribe({
+      next: (message) => {
+        // Add new message to the list
+        const currentMessages = this.messages$.value;
+        this.messages$.next([...currentMessages, message]);
+      },
+    });
+  }
+}

--- a/src/app/features/messages/conversation-header/conversation-header.component.html
+++ b/src/app/features/messages/conversation-header/conversation-header.component.html
@@ -10,11 +10,11 @@
   </button>
 
   <div class="header-icon">
-    <mat-icon>{{ icon }}</mat-icon>
+    <mat-icon>{{ conversation.displayInfo.icon }}</mat-icon>
   </div>
 
   <div class="header-content">
-    <span class="title">{{ title }}</span>
-    <span class="subtitle" *ngIf="subtitle">{{ subtitle }}</span>
+    <span class="title">{{ conversation.displayInfo.title }}</span>
+    <span class="subtitle" *ngIf="conversation.displayInfo.subtitle">{{ conversation.displayInfo.subtitle }}</span>
   </div>
 </div>

--- a/src/app/features/messages/conversation-header/conversation-header.component.html
+++ b/src/app/features/messages/conversation-header/conversation-header.component.html
@@ -1,0 +1,20 @@
+<div class="conversation-header">
+  <button
+    mat-icon-button
+    *ngIf="showBackButton"
+    (click)="onBack()"
+    aria-label="Takaisin"
+    class="back-button"
+  >
+    <mat-icon>arrow_back</mat-icon>
+  </button>
+
+  <div class="header-icon">
+    <mat-icon>{{ icon }}</mat-icon>
+  </div>
+
+  <div class="header-content">
+    <span class="title">{{ title }}</span>
+    <span class="subtitle" *ngIf="subtitle">{{ subtitle }}</span>
+  </div>
+</div>

--- a/src/app/features/messages/conversation-header/conversation-header.component.scss
+++ b/src/app/features/messages/conversation-header/conversation-header.component.scss
@@ -1,0 +1,54 @@
+.conversation-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background-color: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.back-button {
+  margin-left: -0.5rem;
+}
+
+.header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: #e8f5e9;
+  flex-shrink: 0;
+
+  mat-icon {
+    color: #4caf50;
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+.header-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subtitle {
+  font-size: 0.8125rem;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/app/features/messages/conversation-header/conversation-header.component.ts
+++ b/src/app/features/messages/conversation-header/conversation-header.component.ts
@@ -23,18 +23,6 @@ export class ConversationHeaderComponent {
 
   @Output() backClicked = new EventEmitter<void>();
 
-  get icon(): string {
-    return this.conversation.displayInfo.icon;
-  }
-
-  get title(): string {
-    return this.conversation.displayInfo.title;
-  }
-
-  get subtitle(): string | undefined {
-    return this.conversation.displayInfo.subtitle;
-  }
-
   onBack(): void {
     this.backClicked.emit();
   }

--- a/src/app/features/messages/conversation-header/conversation-header.component.ts
+++ b/src/app/features/messages/conversation-header/conversation-header.component.ts
@@ -1,0 +1,41 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+import { Conversation } from '../../../shared/models/message.model';
+import { ConversationDisplayInfo } from '../../../shared/utils/conversation.helpers';
+
+export interface ConversationWithDisplayInfo extends Conversation {
+  displayInfo: ConversationDisplayInfo;
+}
+
+@Component({
+  selector: 'app-conversation-header',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatButtonModule],
+  templateUrl: './conversation-header.component.html',
+  styleUrl: './conversation-header.component.scss',
+})
+export class ConversationHeaderComponent {
+  @Input() conversation!: ConversationWithDisplayInfo;
+  @Input() showBackButton = false;
+
+  @Output() backClicked = new EventEmitter<void>();
+
+  get icon(): string {
+    return this.conversation.displayInfo.icon;
+  }
+
+  get title(): string {
+    return this.conversation.displayInfo.title;
+  }
+
+  get subtitle(): string | undefined {
+    return this.conversation.displayInfo.subtitle;
+  }
+
+  onBack(): void {
+    this.backClicked.emit();
+  }
+}

--- a/src/app/features/messages/conversation-list/conversation-list.component.html
+++ b/src/app/features/messages/conversation-list/conversation-list.component.html
@@ -1,5 +1,5 @@
 <div class="conversation-list">
-  <h2 class="list-header">Viestit</h2>
+  <h2 class="list-header">Keskustelut</h2>
 
   <div class="list-content">
     <app-conversation-card

--- a/src/app/features/messages/conversation-list/conversation-list.component.html
+++ b/src/app/features/messages/conversation-list/conversation-list.component.html
@@ -1,0 +1,12 @@
+<div class="conversation-list">
+  <h2 class="list-header">Viestit</h2>
+
+  <div class="list-content">
+    <app-conversation-card
+      *ngFor="let conversation of conversations"
+      [conversation]="conversation"
+      [isSelected]="selectedConversationId === conversation.id"
+      (click)="onSelectConversation(conversation)"
+    ></app-conversation-card>
+  </div>
+</div>

--- a/src/app/features/messages/conversation-list/conversation-list.component.scss
+++ b/src/app/features/messages/conversation-list/conversation-list.component.scss
@@ -1,0 +1,22 @@
+.conversation-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.list-header {
+  padding: 1rem;
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 500;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.list-content {
+  flex: 1;
+  overflow-y: auto;
+}

--- a/src/app/features/messages/conversation-list/conversation-list.component.ts
+++ b/src/app/features/messages/conversation-list/conversation-list.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ConversationCardComponent } from '../conversation-card/conversation-card.component';
+import { ConversationWithDisplay } from '../messages-page/messages-page.component';
+
+@Component({
+  selector: 'app-conversation-list',
+  standalone: true,
+  imports: [CommonModule, ConversationCardComponent],
+  templateUrl: './conversation-list.component.html',
+  styleUrl: './conversation-list.component.scss',
+})
+export class ConversationListComponent {
+  @Input() conversations: ConversationWithDisplay[] = [];
+  @Input() selectedConversationId: string | null | undefined = null;
+
+  @Output() conversationSelected = new EventEmitter<ConversationWithDisplay>();
+
+  onSelectConversation(conversation: ConversationWithDisplay): void {
+    this.conversationSelected.emit(conversation);
+  }
+}

--- a/src/app/features/messages/message-bubble/message-bubble.component.html
+++ b/src/app/features/messages/message-bubble/message-bubble.component.html
@@ -1,0 +1,5 @@
+<div class="message-bubble" [class.own]="isOwn" [class.received]="!isOwn">
+  <div class="sender-name" *ngIf="!isOwn">{{ message.senderName }}</div>
+  <div class="content" [innerHTML]="formattedContent"></div>
+  <div class="timestamp">{{ timestamp }}</div>
+</div>

--- a/src/app/features/messages/message-bubble/message-bubble.component.scss
+++ b/src/app/features/messages/message-bubble/message-bubble.component.scss
@@ -1,0 +1,43 @@
+.message-bubble {
+  max-width: 75%;
+  padding: 0.625rem 0.875rem;
+  border-radius: 1rem;
+  word-wrap: break-word;
+
+  &.own {
+    align-self: flex-end;
+    background-color: #dcf8c6;
+    border-bottom-right-radius: 0.25rem;
+  }
+
+  &.received {
+    align-self: flex-start;
+    background-color: #fff;
+    border-bottom-left-radius: 0.25rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+}
+
+.sender-name {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #4caf50;
+  margin-bottom: 0.25rem;
+}
+
+.content {
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  color: #333;
+
+  ::ng-deep strong {
+    font-weight: 600;
+  }
+}
+
+.timestamp {
+  font-size: 0.6875rem;
+  color: #888;
+  text-align: right;
+  margin-top: 0.25rem;
+}

--- a/src/app/features/messages/message-bubble/message-bubble.component.ts
+++ b/src/app/features/messages/message-bubble/message-bubble.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { Message } from '../../../shared/models/message.model';
+import { formatMessageContent } from '../../../shared/utils/message-format.helper';
+
+@Component({
+  selector: 'app-message-bubble',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './message-bubble.component.html',
+  styleUrl: './message-bubble.component.scss',
+})
+export class MessageBubbleComponent {
+  @Input() message!: Message;
+  @Input() isOwn = false;
+
+  get formattedContent(): string {
+    return formatMessageContent(this.message.content);
+  }
+
+  get timestamp(): string {
+    const date = this.message.createdAt instanceof Date
+      ? this.message.createdAt
+      : new Date(this.message.createdAt);
+    return date.toLocaleTimeString('fi-FI', { hour: '2-digit', minute: '2-digit' });
+  }
+}

--- a/src/app/features/messages/message-bubble/message-bubble.component.ts
+++ b/src/app/features/messages/message-bubble/message-bubble.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { Message } from '../../../shared/models/message.model';
@@ -11,18 +11,21 @@ import { formatMessageContent } from '../../../shared/utils/message-format.helpe
   templateUrl: './message-bubble.component.html',
   styleUrl: './message-bubble.component.scss',
 })
-export class MessageBubbleComponent {
+export class MessageBubbleComponent implements OnChanges {
   @Input() message!: Message;
   @Input() isOwn = false;
 
-  get formattedContent(): string {
-    return formatMessageContent(this.message.content);
-  }
+  // Computed values (set in ngOnChanges to avoid getter performance issues)
+  formattedContent = '';
+  timestamp = '';
 
-  get timestamp(): string {
-    const date = this.message.createdAt instanceof Date
-      ? this.message.createdAt
-      : new Date(this.message.createdAt);
-    return date.toLocaleTimeString('fi-FI', { hour: '2-digit', minute: '2-digit' });
+  ngOnChanges(): void {
+    this.formattedContent = formatMessageContent(this.message.content);
+
+    const date =
+      this.message.createdAt instanceof Date
+        ? this.message.createdAt
+        : new Date(this.message.createdAt);
+    this.timestamp = date.toLocaleTimeString('fi-FI', { hour: '2-digit', minute: '2-digit' });
   }
 }

--- a/src/app/features/messages/message-input/message-input.component.html
+++ b/src/app/features/messages/message-input/message-input.component.html
@@ -7,6 +7,7 @@
     [disabled]="isSending"
     class="message-textarea"
     aria-label="Viestikenttä"
+    (keydown)="onKeydown($event)"
   ></textarea>
 
   <button

--- a/src/app/features/messages/message-input/message-input.component.html
+++ b/src/app/features/messages/message-input/message-input.component.html
@@ -13,7 +13,7 @@
     mat-icon-button
     color="primary"
     (click)="sendMessage()"
-    [disabled]="!canSend"
+    [disabled]="!messageText.trim() || isSending"
     aria-label="Lähetä"
     class="send-button"
   >

--- a/src/app/features/messages/message-input/message-input.component.html
+++ b/src/app/features/messages/message-input/message-input.component.html
@@ -1,0 +1,22 @@
+<div class="message-input-container">
+  <textarea
+    [(ngModel)]="messageText"
+    placeholder="Kirjoita viesti..."
+    maxlength="1000"
+    rows="2"
+    [disabled]="isSending"
+    class="message-textarea"
+    aria-label="Viestikenttä"
+  ></textarea>
+
+  <button
+    mat-icon-button
+    color="primary"
+    (click)="sendMessage()"
+    [disabled]="!canSend"
+    aria-label="Lähetä"
+    class="send-button"
+  >
+    <mat-icon>send</mat-icon>
+  </button>
+</div>

--- a/src/app/features/messages/message-input/message-input.component.scss
+++ b/src/app/features/messages/message-input/message-input.component.scss
@@ -1,6 +1,6 @@
 .message-input-container {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   background-color: #fff;

--- a/src/app/features/messages/message-input/message-input.component.scss
+++ b/src/app/features/messages/message-input/message-input.component.scss
@@ -1,0 +1,51 @@
+.message-input-container {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fff;
+  border-top: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.message-textarea {
+  flex: 1;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 1.25rem;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s ease;
+
+  &:focus {
+    border-color: #4caf50;
+  }
+
+  &:disabled {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+  }
+
+  &::placeholder {
+    color: #999;
+  }
+}
+
+.send-button {
+  flex-shrink: 0;
+
+  &:disabled {
+    opacity: 0.5;
+  }
+
+  mat-icon {
+    color: #4caf50;
+  }
+
+  &:disabled mat-icon {
+    color: #ccc;
+  }
+}

--- a/src/app/features/messages/message-input/message-input.component.ts
+++ b/src/app/features/messages/message-input/message-input.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-message-input',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatIconModule, MatButtonModule],
+  templateUrl: './message-input.component.html',
+  styleUrl: './message-input.component.scss',
+})
+export class MessageInputComponent {
+  @Output() messageSent = new EventEmitter<string>();
+
+  isSending = false;
+  messageText = '';
+
+  get canSend(): boolean {
+    return this.messageText.trim().length > 0 && !this.isSending;
+  }
+
+  sendMessage(): void {
+    if (!this.canSend) return;
+
+    const content = this.messageText.trim();
+    this.isSending = true;
+    this.messageSent.emit(content);
+
+    // Reset state (parent will handle actual sending)
+    this.messageText = '';
+    this.isSending = false;
+  }
+}

--- a/src/app/features/messages/message-input/message-input.component.ts
+++ b/src/app/features/messages/message-input/message-input.component.ts
@@ -17,14 +17,10 @@ export class MessageInputComponent {
   isSending = false;
   messageText = '';
 
-  get canSend(): boolean {
-    return this.messageText.trim().length > 0 && !this.isSending;
-  }
-
   sendMessage(): void {
-    if (!this.canSend) return;
-
     const content = this.messageText.trim();
+    if (!content || this.isSending) return;
+
     this.isSending = true;
     this.messageSent.emit(content);
 

--- a/src/app/features/messages/message-input/message-input.component.ts
+++ b/src/app/features/messages/message-input/message-input.component.ts
@@ -17,6 +17,15 @@ export class MessageInputComponent {
   isSending = false;
   messageText = '';
 
+  onKeydown(event: KeyboardEvent): void {
+    // Enter without Shift sends the message
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.sendMessage();
+    }
+    // Shift+Enter allows default behavior (line break)
+  }
+
   sendMessage(): void {
     const content = this.messageText.trim();
     if (!content || this.isSending) return;

--- a/src/app/features/messages/message-thread/message-thread.component.html
+++ b/src/app/features/messages/message-thread/message-thread.component.html
@@ -1,0 +1,16 @@
+<div class="message-thread" #scrollContainer>
+  <!-- Empty state -->
+  <div class="empty-state" *ngIf="messages.length === 0">
+    <span class="material-icons">chat_bubble_outline</span>
+    <p>Aloita keskustelu!</p>
+  </div>
+
+  <!-- Messages -->
+  <div class="messages-container" *ngIf="messages.length > 0">
+    <app-message-bubble
+      *ngFor="let message of messages; trackBy: trackByMessageId"
+      [message]="message"
+      [isOwn]="isOwnMessage(message)"
+    ></app-message-bubble>
+  </div>
+</div>

--- a/src/app/features/messages/message-thread/message-thread.component.scss
+++ b/src/app/features/messages/message-thread/message-thread.component.scss
@@ -1,8 +1,17 @@
+:host {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0; // Important for flex overflow
+}
+
 .message-thread {
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
   background-color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
 }
 
 .empty-state {
@@ -29,4 +38,5 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin-top: auto;
 }

--- a/src/app/features/messages/message-thread/message-thread.component.scss
+++ b/src/app/features/messages/message-thread/message-thread.component.scss
@@ -1,0 +1,32 @@
+.message-thread {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.5rem;
+  color: #888;
+
+  .material-icons {
+    font-size: 3rem;
+    color: #ccc;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+}
+
+.messages-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/app/features/messages/message-thread/message-thread.component.ts
+++ b/src/app/features/messages/message-thread/message-thread.component.ts
@@ -1,0 +1,49 @@
+import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild, AfterViewChecked } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { Message } from '../../../shared/models/message.model';
+import { MessageBubbleComponent } from '../message-bubble/message-bubble.component';
+
+@Component({
+  selector: 'app-message-thread',
+  standalone: true,
+  imports: [CommonModule, MessageBubbleComponent],
+  templateUrl: './message-thread.component.html',
+  styleUrl: './message-thread.component.scss',
+})
+export class MessageThreadComponent implements OnChanges, AfterViewChecked {
+  @Input() messages: Message[] = [];
+  @Input() currentUserId: string | undefined;
+
+  @ViewChild('scrollContainer') private scrollContainer!: ElementRef<HTMLDivElement>;
+
+  private shouldScrollToBottom = false;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['messages']) {
+      this.shouldScrollToBottom = true;
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    if (this.shouldScrollToBottom) {
+      this.scrollToBottom();
+      this.shouldScrollToBottom = false;
+    }
+  }
+
+  isOwnMessage(message: Message): boolean {
+    return message.senderId === this.currentUserId;
+  }
+
+  trackByMessageId(_index: number, message: Message): string {
+    return message.id;
+  }
+
+  private scrollToBottom(): void {
+    if (this.scrollContainer) {
+      const container = this.scrollContainer.nativeElement;
+      container.scrollTop = container.scrollHeight;
+    }
+  }
+}

--- a/src/app/features/messages/messages-page/messages-page.component.html
+++ b/src/app/features/messages/messages-page/messages-page.component.html
@@ -7,8 +7,8 @@
     </div>
 
     <ng-container *ngIf="!vm.loading">
-      <!-- Conversation list -->
-      <div class="conversation-list-panel" *ngIf="!vm.showSplitView || !vm.selectedConversation">
+      <!-- Conversation list (always shown, either full width or as sidebar) -->
+      <div class="conversation-list-panel">
         <app-conversation-list
           [conversations]="vm.conversations"
           [selectedConversationId]="vm.selectedConversation?.id"
@@ -16,16 +16,8 @@
         ></app-conversation-list>
       </div>
 
-      <!-- Split view: show both panels -->
+      <!-- Chat panel (only in split view) -->
       <ng-container *ngIf="vm.showSplitView">
-        <div class="conversation-list-panel">
-          <app-conversation-list
-            [conversations]="vm.conversations"
-            [selectedConversationId]="vm.selectedConversation?.id"
-            (conversationSelected)="onConversationSelected($event, vm.showSplitView)"
-          ></app-conversation-list>
-        </div>
-
         <div class="chat-panel" *ngIf="vm.selectedConversation">
           <app-conversation-header
             [conversation]="vm.selectedConversation"

--- a/src/app/features/messages/messages-page/messages-page.component.html
+++ b/src/app/features/messages/messages-page/messages-page.component.html
@@ -1,0 +1,64 @@
+<ng-container *ngIf="vm$ | async as vm">
+  <div class="messages-page" [class.split-view]="vm.showSplitView">
+    <!-- Loading state -->
+    <div class="loading-container" *ngIf="vm.loading">
+      <mat-spinner diameter="40"></mat-spinner>
+      <span>Ladataan keskusteluja...</span>
+    </div>
+
+    <ng-container *ngIf="!vm.loading">
+      <!-- Conversation list -->
+      <div class="conversation-list-panel" *ngIf="!vm.showSplitView || !vm.selectedConversation">
+        <app-conversation-list
+          [conversations]="vm.conversations"
+          [selectedConversationId]="vm.selectedConversation?.id"
+          (conversationSelected)="onConversationSelected($event, vm.showSplitView)"
+        ></app-conversation-list>
+      </div>
+
+      <!-- Split view: show both panels -->
+      <ng-container *ngIf="vm.showSplitView">
+        <div class="conversation-list-panel">
+          <app-conversation-list
+            [conversations]="vm.conversations"
+            [selectedConversationId]="vm.selectedConversation?.id"
+            (conversationSelected)="onConversationSelected($event, vm.showSplitView)"
+          ></app-conversation-list>
+        </div>
+
+        <div class="chat-panel" *ngIf="vm.selectedConversation">
+          <app-conversation-header
+            [conversation]="vm.selectedConversation"
+            [showBackButton]="false"
+          ></app-conversation-header>
+
+          <app-message-thread
+            [messages]="vm.messages"
+            [currentUserId]="vm.currentUserId"
+          ></app-message-thread>
+
+          <app-message-input
+            (messageSent)="onMessageSent(vm.selectedConversation.id, $event)"
+          ></app-message-input>
+        </div>
+
+        <!-- Empty state when no conversation selected -->
+        <div class="chat-panel empty-state" *ngIf="!vm.selectedConversation && vm.conversations.length > 0">
+          <div class="empty-content">
+            <span class="material-icons">chat</span>
+            <p>Valitse keskustelu vasemmalta</p>
+          </div>
+        </div>
+      </ng-container>
+
+      <!-- Empty state when no conversations -->
+      <div class="empty-state full-page" *ngIf="vm.conversations.length === 0">
+        <div class="empty-content">
+          <span class="material-icons">forum</span>
+          <h2>Ei vielä keskusteluja</h2>
+          <p>Kun aloitat keskustelun toisen vanhemman kanssa, se näkyy täällä.</p>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+</ng-container>

--- a/src/app/features/messages/messages-page/messages-page.component.html
+++ b/src/app/features/messages/messages-page/messages-page.component.html
@@ -1,56 +1,28 @@
-<ng-container *ngIf="vm$ | async as vm">
-  <div class="messages-page" [class.split-view]="vm.showSplitView">
+<div class="messages-page">
+  <ng-container *ngIf="vm$ | async as vm">
     <!-- Loading state -->
-    <div class="loading-container" *ngIf="vm.loading">
+    <div *ngIf="vm.loading" class="loading-container">
       <mat-spinner diameter="40"></mat-spinner>
       <span>Ladataan keskusteluja...</span>
     </div>
 
-    <ng-container *ngIf="!vm.loading">
-      <!-- Conversation list (always shown, either full width or as sidebar) -->
-      <div class="conversation-list-panel">
-        <app-conversation-list
-          [conversations]="vm.conversations"
-          [selectedConversationId]="vm.selectedConversation?.id"
-          (conversationSelected)="onConversationSelected($event, vm.showSplitView)"
-        ></app-conversation-list>
+    <!-- Content -->
+    <div *ngIf="!vm.loading" class="messages-content">
+      <!-- Empty state -->
+      <div *ngIf="vm.conversations.length === 0" class="empty-state">
+        <mat-icon>forum</mat-icon>
+        <h2>Ei vielä keskusteluja</h2>
+        <p>Kun aloitat keskustelun toisen vanhemman kanssa, se näkyy täällä.</p>
       </div>
 
-      <!-- Chat panel (only in split view) -->
-      <ng-container *ngIf="vm.showSplitView">
-        <div class="chat-panel" *ngIf="vm.selectedConversation">
-          <app-conversation-header
-            [conversation]="vm.selectedConversation"
-            [showBackButton]="false"
-          ></app-conversation-header>
-
-          <app-message-thread
-            [messages]="vm.messages"
-            [currentUserId]="vm.currentUserId"
-          ></app-message-thread>
-
-          <app-message-input
-            (messageSent)="onMessageSent(vm.selectedConversation.id, $event)"
-          ></app-message-input>
-        </div>
-
-        <!-- Empty state when no conversation selected -->
-        <div class="chat-panel empty-state" *ngIf="!vm.selectedConversation && vm.conversations.length > 0">
-          <div class="empty-content">
-            <span class="material-icons">chat</span>
-            <p>Valitse keskustelu vasemmalta</p>
-          </div>
-        </div>
-      </ng-container>
-
-      <!-- Empty state when no conversations -->
-      <div class="empty-state full-page" *ngIf="vm.conversations.length === 0">
-        <div class="empty-content">
-          <span class="material-icons">forum</span>
-          <h2>Ei vielä keskusteluja</h2>
-          <p>Kun aloitat keskustelun toisen vanhemman kanssa, se näkyy täällä.</p>
-        </div>
+      <!-- Conversations grid -->
+      <div *ngIf="vm.conversations.length > 0" class="conversations-grid">
+        <app-conversation-card
+          *ngFor="let conversation of vm.conversations"
+          [conversation]="conversation"
+          (click)="onConversationSelected(conversation)"
+        ></app-conversation-card>
       </div>
-    </ng-container>
-  </div>
-</ng-container>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/features/messages/messages-page/messages-page.component.html
+++ b/src/app/features/messages/messages-page/messages-page.component.html
@@ -1,28 +1,55 @@
-<div class="messages-page">
-  <ng-container *ngIf="vm$ | async as vm">
+<ng-container *ngIf="vm$ | async as vm">
+  <div class="messages-page">
     <!-- Loading state -->
-    <div *ngIf="vm.loading" class="loading-container">
+    <div class="loading-container" *ngIf="vm.loading">
       <mat-spinner diameter="40"></mat-spinner>
       <span>Ladataan keskusteluja...</span>
     </div>
 
-    <!-- Content -->
-    <div *ngIf="!vm.loading" class="messages-content">
-      <!-- Empty state -->
-      <div *ngIf="vm.conversations.length === 0" class="empty-state">
+    <ng-container *ngIf="!vm.loading">
+      <!-- Empty state when no conversations -->
+      <div class="empty-state" *ngIf="vm.conversations.length === 0">
         <mat-icon>forum</mat-icon>
         <h2>Ei vielä keskusteluja</h2>
         <p>Kun aloitat keskustelun toisen vanhemman kanssa, se näkyy täällä.</p>
       </div>
 
-      <!-- Conversations grid -->
-      <div *ngIf="vm.conversations.length > 0" class="conversations-grid">
-        <app-conversation-card
-          *ngFor="let conversation of vm.conversations"
-          [conversation]="conversation"
-          (click)="onConversationSelected(conversation)"
-        ></app-conversation-card>
-      </div>
-    </div>
-  </ng-container>
-</div>
+      <!-- WhatsApp-style split view -->
+      <ng-container *ngIf="vm.conversations.length > 0">
+        <!-- Conversation list panel -->
+        <div class="conversation-list-panel">
+          <app-conversation-list
+            [conversations]="vm.conversations"
+            [selectedConversationId]="vm.selectedConversation?.id"
+            (conversationSelected)="onConversationSelected($event, vm.isDesktop)"
+          ></app-conversation-list>
+        </div>
+
+        <!-- Chat panel -->
+        <div class="chat-panel" *ngIf="vm.selectedConversation">
+          <app-conversation-header
+            [conversation]="vm.selectedConversation"
+            [showBackButton]="false"
+          ></app-conversation-header>
+
+          <app-message-thread
+            [messages]="vm.messages"
+            [currentUserId]="vm.currentUserId"
+          ></app-message-thread>
+
+          <app-message-input
+            (messageSent)="onMessageSent(vm.selectedConversation.id, $event)"
+          ></app-message-input>
+        </div>
+
+        <!-- Placeholder when no conversation selected -->
+        <div class="chat-panel placeholder" *ngIf="!vm.selectedConversation">
+          <div class="placeholder-content">
+            <mat-icon>chat</mat-icon>
+            <p>Valitse keskustelu vasemmalta</p>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
+  </div>
+</ng-container>

--- a/src/app/features/messages/messages-page/messages-page.component.scss
+++ b/src/app/features/messages/messages-page/messages-page.component.scss
@@ -1,0 +1,87 @@
+.messages-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 4rem); // Account for header
+  background-color: #fafafa;
+
+  &.split-view {
+    flex-direction: row;
+  }
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 1rem;
+  color: #666;
+}
+
+.conversation-list-panel {
+  height: 100%;
+  overflow-y: auto;
+  background-color: #fff;
+  border-right: 1px solid #e0e0e0;
+
+  .split-view & {
+    width: 20rem;
+    min-width: 18rem;
+    max-width: 25rem;
+    flex-shrink: 0;
+  }
+}
+
+.chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #fff;
+
+  &.empty-state {
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+
+  &.full-page {
+    height: 100%;
+  }
+
+  .empty-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    color: #666;
+
+    .material-icons {
+      font-size: 4rem;
+      color: #ccc;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 500;
+      color: #333;
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.875rem;
+      color: #888;
+      max-width: 20rem;
+    }
+  }
+}

--- a/src/app/features/messages/messages-page/messages-page.component.scss
+++ b/src/app/features/messages/messages-page/messages-page.component.scss
@@ -1,93 +1,21 @@
-.messages-page {
-  display: flex;
-  flex-direction: column;
-  height: calc(100vh - 4rem); // Account for header
-  background-color: #fafafa;
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
+@use '../../../shared/styles/page-layout' as page;
 
-  &.split-view {
-    flex-direction: row;
-  }
+.messages-page {
+  @include page.page-container;
+}
+
+.messages-content {
+  @include page.content-container;
 }
 
 .loading-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  gap: 1rem;
-  color: #666;
-}
-
-.conversation-list-panel {
-  height: 100%;
-  overflow-y: auto;
-  background-color: #fff;
-  border-right: 1px solid #e0e0e0;
-
-  .split-view & {
-    width: 20rem;
-    min-width: 18rem;
-    max-width: 25rem;
-    flex-shrink: 0;
-  }
-}
-
-.chat-panel {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background-color: #fff;
-
-  &.empty-state {
-    justify-content: center;
-    align-items: center;
-  }
+  @include page.loading-container;
 }
 
 .empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-  text-align: center;
+  @include page.empty-state;
+}
 
-  &.full-page {
-    height: 100%;
-  }
-
-  .empty-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    color: #666;
-
-    .material-icons {
-      font-size: 4rem;
-      color: #ccc;
-    }
-
-    h2 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 500;
-      color: #333;
-    }
-
-    p {
-      margin: 0;
-      font-size: 0.875rem;
-      color: #888;
-      max-width: 20rem;
-    }
-  }
+.conversations-grid {
+  @include page.card-grid;
 }

--- a/src/app/features/messages/messages-page/messages-page.component.scss
+++ b/src/app/features/messages/messages-page/messages-page.component.scss
@@ -1,7 +1,8 @@
 .messages-page {
   display: flex;
   flex-direction: row;
-  height: calc(100vh - 4rem); // Account for header
+  height: calc(100vh - 5.5rem); // Account for header (~88px)
+  height: calc(100dvh - 5.5rem); // Use dynamic viewport height for mobile
   background-color: #fafafa;
   max-width: 1200px;
   margin: 0 auto;

--- a/src/app/features/messages/messages-page/messages-page.component.scss
+++ b/src/app/features/messages/messages-page/messages-page.component.scss
@@ -3,6 +3,9 @@
   flex-direction: column;
   height: calc(100vh - 4rem); // Account for header
   background-color: #fafafa;
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
 
   &.split-view {
     flex-direction: row;
@@ -14,7 +17,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   gap: 1rem;
   color: #666;
 }

--- a/src/app/features/messages/messages-page/messages-page.component.scss
+++ b/src/app/features/messages/messages-page/messages-page.component.scss
@@ -1,21 +1,109 @@
-@use '../../../shared/styles/page-layout' as page;
-
 .messages-page {
-  @include page.page-container;
-}
-
-.messages-content {
-  @include page.content-container;
+  display: flex;
+  flex-direction: row;
+  height: calc(100vh - 4rem); // Account for header
+  background-color: #fafafa;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .loading-container {
-  @include page.loading-container;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  gap: 1rem;
+  color: #666;
 }
 
 .empty-state {
-  @include page.empty-state;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 2rem;
+  text-align: center;
+
+  mat-icon {
+    font-size: 4rem;
+    width: 4rem;
+    height: 4rem;
+    color: #ccc;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: #333;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #888;
+    max-width: 20rem;
+  }
 }
 
-.conversations-grid {
-  @include page.card-grid;
+.conversation-list-panel {
+  width: 20rem;
+  min-width: 18rem;
+  max-width: 22rem;
+  height: 100%;
+  overflow-y: auto;
+  background-color: #fff;
+  border-right: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #fff;
+
+  &.placeholder {
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+.placeholder-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  color: #888;
+
+  mat-icon {
+    font-size: 4rem;
+    width: 4rem;
+    height: 4rem;
+    color: #ccc;
+  }
+
+  p {
+    margin: 0;
+    font-size: 1rem;
+  }
+}
+
+// Mobile: hide chat panel, show only list
+@media (max-width: 959px) {
+  .conversation-list-panel {
+    width: 100%;
+    max-width: 100%;
+    border-right: none;
+  }
+
+  .chat-panel {
+    display: none;
+  }
 }

--- a/src/app/features/messages/messages-page/messages-page.component.ts
+++ b/src/app/features/messages/messages-page/messages-page.component.ts
@@ -1,0 +1,129 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { BehaviorSubject, combineLatest, map, switchMap, of } from 'rxjs';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { MessageService } from '../../../shared/services/message.service';
+import { UserService } from '../../../core/services/user.service';
+import { BreakpointService } from '../../../shared/services/breakpoint.service';
+import { Conversation, Message } from '../../../shared/models/message.model';
+import {
+  sortConversations,
+  getConversationDisplayInfo,
+  ConversationDisplayInfo,
+} from '../../../shared/utils/conversation.helpers';
+
+import { ConversationListComponent } from '../conversation-list/conversation-list.component';
+import { ConversationHeaderComponent } from '../conversation-header/conversation-header.component';
+import { MessageThreadComponent } from '../message-thread/message-thread.component';
+import { MessageInputComponent } from '../message-input/message-input.component';
+
+export interface ConversationWithDisplay extends Conversation {
+  displayInfo: ConversationDisplayInfo;
+  hasUnread: boolean;
+}
+
+@Component({
+  selector: 'app-messages-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatProgressSpinnerModule,
+    ConversationListComponent,
+    ConversationHeaderComponent,
+    MessageThreadComponent,
+    MessageInputComponent,
+  ],
+  templateUrl: './messages-page.component.html',
+  styleUrl: './messages-page.component.scss',
+})
+export class MessagesPageComponent implements OnInit {
+  private readonly breakpointService = inject(BreakpointService);
+  private readonly messageService = inject(MessageService);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  private loading$ = new BehaviorSubject<boolean>(true);
+  private selectedConversationId$ = new BehaviorSubject<string | null>(null);
+
+  vm$ = combineLatest({
+    conversations: this.messageService.conversations$,
+    selectedConversationId: this.selectedConversationId$,
+    currentUser: this.userService.currentUser$,
+    breakpoint: this.breakpointService.breakpoint$,
+    loading: this.loading$,
+  }).pipe(
+    switchMap(({ conversations, selectedConversationId, currentUser, breakpoint, loading }) => {
+      const currentUserId = currentUser?.id;
+      const showSplitView = breakpoint.gtS; // ≥960px shows split view
+
+      // Sort and transform conversations
+      const sortedConversations: ConversationWithDisplay[] = sortConversations(conversations).map(
+        (conv) => ({
+          ...conv,
+          displayInfo: getConversationDisplayInfo(conv, currentUserId),
+          hasUnread: conv.unreadCount > 0,
+        })
+      );
+
+      const selectedConversation = sortedConversations.find(
+        (c) => c.id === selectedConversationId
+      );
+
+      // Load messages for selected conversation
+      if (selectedConversation && showSplitView) {
+        return this.messageService.getMessages(selectedConversation.id).pipe(
+          map((messages) => ({
+            conversations: sortedConversations,
+            selectedConversation,
+            messages,
+            showSplitView,
+            totalUnread: conversations.reduce((sum, c) => sum + c.unreadCount, 0),
+            currentUserId,
+            loading,
+          }))
+        );
+      }
+
+      return of({
+        conversations: sortedConversations,
+        selectedConversation: selectedConversation || null,
+        messages: [] as Message[],
+        showSplitView,
+        totalUnread: conversations.reduce((sum, c) => sum + c.unreadCount, 0),
+        currentUserId,
+        loading,
+      });
+    })
+  );
+
+  ngOnInit(): void {
+    this.messageService.getConversations().subscribe({
+      next: () => this.loading$.next(false),
+      error: () => this.loading$.next(false),
+    });
+  }
+
+  onConversationSelected(conversation: ConversationWithDisplay, showSplitView: boolean): void {
+    if (showSplitView) {
+      // Desktop: update selection, show in split view
+      this.selectedConversationId$.next(conversation.id);
+      // Mark as read
+      if (conversation.hasUnread) {
+        this.messageService.markAsRead(conversation.id).subscribe();
+      }
+    } else {
+      // Mobile: navigate to detail page
+      this.router.navigate(['/messages', conversation.id]);
+    }
+  }
+
+  onMessageSent(conversationId: string, content: string): void {
+    this.messageService.sendMessage(conversationId, { content }).subscribe();
+  }
+
+  onBackToList(): void {
+    this.selectedConversationId$.next(null);
+  }
+}

--- a/src/app/features/messages/messages-page/messages-page.component.ts
+++ b/src/app/features/messages/messages-page/messages-page.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, map, switchMap, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, switchMap, of, Subject, timer } from 'rxjs';
+import { takeUntil, switchMap as rxSwitchMap } from 'rxjs/operators';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -25,6 +26,8 @@ export interface ConversationWithDisplay extends Conversation {
   hasUnread: boolean;
 }
 
+const MARK_AS_READ_DELAY_MS = 2000; // 2 seconds delay before marking as read
+
 @Component({
   selector: 'app-messages-page',
   standalone: true,
@@ -40,11 +43,14 @@ export interface ConversationWithDisplay extends Conversation {
   templateUrl: './messages-page.component.html',
   styleUrl: './messages-page.component.scss',
 })
-export class MessagesPageComponent implements OnInit {
+export class MessagesPageComponent implements OnInit, OnDestroy {
   private readonly breakpointService = inject(BreakpointService);
   private readonly messageService = inject(MessageService);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
+
+  private readonly destroy$ = new Subject<void>();
+  private readonly markAsRead$ = new Subject<string>();
 
   private loading$ = new BehaviorSubject<boolean>(true);
   private selectedConversationId$ = new BehaviorSubject<string | null>(null);
@@ -103,15 +109,33 @@ export class MessagesPageComponent implements OnInit {
       next: () => this.loading$.next(false),
       error: () => this.loading$.next(false),
     });
+
+    // Set up delayed mark-as-read: waits 2 seconds after conversation selection
+    // If user switches to another conversation before 2s, the previous one is cancelled
+    this.markAsRead$
+      .pipe(
+        rxSwitchMap((conversationId) =>
+          timer(MARK_AS_READ_DELAY_MS).pipe(
+            rxSwitchMap(() => this.messageService.markAsRead(conversationId))
+          )
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   onConversationSelected(conversation: ConversationWithDisplay, isDesktop: boolean): void {
     if (isDesktop) {
       // Desktop: update selection, show in split view
       this.selectedConversationId$.next(conversation.id);
-      // Mark as read
+      // Schedule mark as read after delay (if conversation has unread messages)
       if (conversation.hasUnread) {
-        this.messageService.markAsRead(conversation.id).subscribe();
+        this.markAsRead$.next(conversation.id);
       }
     } else {
       // Mobile: navigate to detail page

--- a/src/app/features/messages/messages-page/messages-page.component.ts
+++ b/src/app/features/messages/messages-page/messages-page.component.ts
@@ -1,23 +1,20 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, map, switchMap, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, map } from 'rxjs';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatIconModule } from '@angular/material/icon';
 
 import { MessageService } from '../../../shared/services/message.service';
 import { UserService } from '../../../core/services/user.service';
-import { BreakpointService } from '../../../shared/services/breakpoint.service';
-import { Conversation, Message } from '../../../shared/models/message.model';
+import { Conversation } from '../../../shared/models/message.model';
 import {
   sortConversations,
   getConversationDisplayInfo,
   ConversationDisplayInfo,
 } from '../../../shared/utils/conversation.helpers';
 
-import { ConversationListComponent } from '../conversation-list/conversation-list.component';
-import { ConversationHeaderComponent } from '../conversation-header/conversation-header.component';
-import { MessageThreadComponent } from '../message-thread/message-thread.component';
-import { MessageInputComponent } from '../message-input/message-input.component';
+import { ConversationCardComponent } from '../conversation-card/conversation-card.component';
 
 export interface ConversationWithDisplay extends Conversation {
   displayInfo: ConversationDisplayInfo;
@@ -30,33 +27,26 @@ export interface ConversationWithDisplay extends Conversation {
   imports: [
     CommonModule,
     MatProgressSpinnerModule,
-    ConversationListComponent,
-    ConversationHeaderComponent,
-    MessageThreadComponent,
-    MessageInputComponent,
+    MatIconModule,
+    ConversationCardComponent,
   ],
   templateUrl: './messages-page.component.html',
   styleUrl: './messages-page.component.scss',
 })
 export class MessagesPageComponent implements OnInit {
-  private readonly breakpointService = inject(BreakpointService);
   private readonly messageService = inject(MessageService);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
 
   private loading$ = new BehaviorSubject<boolean>(true);
-  private selectedConversationId$ = new BehaviorSubject<string | null>(null);
 
   vm$ = combineLatest({
     conversations: this.messageService.conversations$,
-    selectedConversationId: this.selectedConversationId$,
     currentUser: this.userService.currentUser$,
-    breakpoint: this.breakpointService.breakpoint$,
     loading: this.loading$,
   }).pipe(
-    switchMap(({ conversations, selectedConversationId, currentUser, breakpoint, loading }) => {
+    map(({ conversations, currentUser, loading }) => {
       const currentUserId = currentUser?.id;
-      const showSplitView = breakpoint.gtS; // ≥960px shows split view
 
       // Sort and transform conversations
       const sortedConversations: ConversationWithDisplay[] = sortConversations(conversations).map(
@@ -67,34 +57,10 @@ export class MessagesPageComponent implements OnInit {
         })
       );
 
-      const selectedConversation = sortedConversations.find(
-        (c) => c.id === selectedConversationId
-      );
-
-      // Load messages for selected conversation
-      if (selectedConversation && showSplitView) {
-        return this.messageService.getMessages(selectedConversation.id).pipe(
-          map((messages) => ({
-            conversations: sortedConversations,
-            selectedConversation,
-            messages,
-            showSplitView,
-            totalUnread: conversations.reduce((sum, c) => sum + c.unreadCount, 0),
-            currentUserId,
-            loading,
-          }))
-        );
-      }
-
-      return of({
+      return {
         conversations: sortedConversations,
-        selectedConversation: selectedConversation || null,
-        messages: [] as Message[],
-        showSplitView,
-        totalUnread: conversations.reduce((sum, c) => sum + c.unreadCount, 0),
-        currentUserId,
         loading,
-      });
+      };
     })
   );
 
@@ -105,25 +71,8 @@ export class MessagesPageComponent implements OnInit {
     });
   }
 
-  onConversationSelected(conversation: ConversationWithDisplay, showSplitView: boolean): void {
-    if (showSplitView) {
-      // Desktop: update selection, show in split view
-      this.selectedConversationId$.next(conversation.id);
-      // Mark as read
-      if (conversation.hasUnread) {
-        this.messageService.markAsRead(conversation.id).subscribe();
-      }
-    } else {
-      // Mobile: navigate to detail page
-      this.router.navigate(['/messages', conversation.id]);
-    }
-  }
-
-  onMessageSent(conversationId: string, content: string): void {
-    this.messageService.sendMessage(conversationId, { content }).subscribe();
-  }
-
-  onBackToList(): void {
-    this.selectedConversationId$.next(null);
+  onConversationSelected(conversation: ConversationWithDisplay): void {
+    // Navigate to detail page
+    this.router.navigate(['/messages', conversation.id]);
   }
 }

--- a/src/app/features/messages/messages-page/messages-page.component.ts
+++ b/src/app/features/messages/messages-page/messages-page.component.ts
@@ -144,6 +144,9 @@ export class MessagesPageComponent implements OnInit, OnDestroy {
   }
 
   onMessageSent(conversationId: string, content: string): void {
-    this.messageService.sendMessage(conversationId, { content }).subscribe();
+    this.messageService.sendMessage(conversationId, { content }).subscribe(() => {
+      // Re-emit to trigger messages refresh
+      this.selectedConversationId$.next(conversationId);
+    });
   }
 }

--- a/src/app/features/messages/messages-page/messages-page.component.ts
+++ b/src/app/features/messages/messages-page/messages-page.component.ts
@@ -1,20 +1,24 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, map } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, switchMap, of } from 'rxjs';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIconModule } from '@angular/material/icon';
 
 import { MessageService } from '../../../shared/services/message.service';
 import { UserService } from '../../../core/services/user.service';
-import { Conversation } from '../../../shared/models/message.model';
+import { BreakpointService } from '../../../shared/services/breakpoint.service';
+import { Conversation, Message } from '../../../shared/models/message.model';
 import {
   sortConversations,
   getConversationDisplayInfo,
   ConversationDisplayInfo,
 } from '../../../shared/utils/conversation.helpers';
 
-import { ConversationCardComponent } from '../conversation-card/conversation-card.component';
+import { ConversationListComponent } from '../conversation-list/conversation-list.component';
+import { ConversationHeaderComponent } from '../conversation-header/conversation-header.component';
+import { MessageThreadComponent } from '../message-thread/message-thread.component';
+import { MessageInputComponent } from '../message-input/message-input.component';
 
 export interface ConversationWithDisplay extends Conversation {
   displayInfo: ConversationDisplayInfo;
@@ -28,25 +32,33 @@ export interface ConversationWithDisplay extends Conversation {
     CommonModule,
     MatProgressSpinnerModule,
     MatIconModule,
-    ConversationCardComponent,
+    ConversationListComponent,
+    ConversationHeaderComponent,
+    MessageThreadComponent,
+    MessageInputComponent,
   ],
   templateUrl: './messages-page.component.html',
   styleUrl: './messages-page.component.scss',
 })
 export class MessagesPageComponent implements OnInit {
+  private readonly breakpointService = inject(BreakpointService);
   private readonly messageService = inject(MessageService);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
 
   private loading$ = new BehaviorSubject<boolean>(true);
+  private selectedConversationId$ = new BehaviorSubject<string | null>(null);
 
   vm$ = combineLatest({
     conversations: this.messageService.conversations$,
+    selectedConversationId: this.selectedConversationId$,
     currentUser: this.userService.currentUser$,
+    breakpoint: this.breakpointService.breakpoint$,
     loading: this.loading$,
   }).pipe(
-    map(({ conversations, currentUser, loading }) => {
+    switchMap(({ conversations, selectedConversationId, currentUser, breakpoint, loading }) => {
       const currentUserId = currentUser?.id;
+      const isDesktop = breakpoint.gtS; // ≥960px
 
       // Sort and transform conversations
       const sortedConversations: ConversationWithDisplay[] = sortConversations(conversations).map(
@@ -57,10 +69,32 @@ export class MessagesPageComponent implements OnInit {
         })
       );
 
-      return {
+      const selectedConversation = sortedConversations.find(
+        (c) => c.id === selectedConversationId
+      );
+
+      // Load messages for selected conversation
+      if (selectedConversation) {
+        return this.messageService.getMessages(selectedConversation.id).pipe(
+          map((messages) => ({
+            conversations: sortedConversations,
+            selectedConversation,
+            messages,
+            isDesktop,
+            currentUserId,
+            loading,
+          }))
+        );
+      }
+
+      return of({
         conversations: sortedConversations,
+        selectedConversation: null as ConversationWithDisplay | null,
+        messages: [] as Message[],
+        isDesktop,
+        currentUserId,
         loading,
-      };
+      });
     })
   );
 
@@ -71,8 +105,21 @@ export class MessagesPageComponent implements OnInit {
     });
   }
 
-  onConversationSelected(conversation: ConversationWithDisplay): void {
-    // Navigate to detail page
-    this.router.navigate(['/messages', conversation.id]);
+  onConversationSelected(conversation: ConversationWithDisplay, isDesktop: boolean): void {
+    if (isDesktop) {
+      // Desktop: update selection, show in split view
+      this.selectedConversationId$.next(conversation.id);
+      // Mark as read
+      if (conversation.hasUnread) {
+        this.messageService.markAsRead(conversation.id).subscribe();
+      }
+    } else {
+      // Mobile: navigate to detail page
+      this.router.navigate(['/messages', conversation.id]);
+    }
+  }
+
+  onMessageSent(conversationId: string, content: string): void {
+    this.messageService.sendMessage(conversationId, { content }).subscribe();
   }
 }

--- a/src/app/shared/models/index.ts
+++ b/src/app/shared/models/index.ts
@@ -1,4 +1,5 @@
 // Barrel export for models
+export * from './friend-request.model';
+export * from './message.model';
 export * from './playground.model';
 export * from './playtime.model';
-export * from './friend-request.model';

--- a/src/app/shared/models/message.model.ts
+++ b/src/app/shared/models/message.model.ts
@@ -1,0 +1,61 @@
+export type ConversationContextType = 'playtime' | 'friend_request' | 'general';
+
+export interface Conversation {
+  id: string;
+  participants: ConversationParticipant[];
+  context?: ConversationContext;
+  lastMessage?: LastMessage;
+  unreadCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ConversationParticipant {
+  id: string;
+  displayName: string;
+}
+
+export interface ConversationContext {
+  type: ConversationContextType;
+
+  // Populated based on type
+  playtime?: {
+    id: string;
+    playgroundName: string;
+    scheduledTime: Date;
+    duration: number;
+  };
+  friendRequest?: {
+    id: string;
+    childName: string;
+    childAge: number;
+  };
+  topic?: string; // For general type with custom topic
+}
+
+export interface LastMessage {
+  content: string;
+  senderId: string;
+  createdAt: Date;
+}
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  read: boolean;
+  createdAt: Date;
+}
+
+export interface CreateMessageDto {
+  content: string;
+}
+
+export interface CreateConversationDto {
+  participantId: string;
+  contextType?: ConversationContextType;
+  contextId?: string; // Required for 'playtime' or 'friend_request'
+  customTopic?: string; // Optional for 'general' type
+}

--- a/src/app/shared/services/index.ts
+++ b/src/app/shared/services/index.ts
@@ -1,5 +1,6 @@
 // Barrel export for services
 export * from './breakpoint.service';
 export * from './friend-request.service';
+export * from './message.service';
 export * from './playground.service';
 export * from './playtime.service';

--- a/src/app/shared/services/message.service.ts
+++ b/src/app/shared/services/message.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, BehaviorSubject, tap, map, of } from 'rxjs';
+import { Observable, BehaviorSubject, tap, map } from 'rxjs';
 import {
   Conversation,
   Message,
@@ -10,207 +10,12 @@ import {
 } from '../models/message.model';
 import { environment } from '../../../environments/environment';
 
-// Mock data for local development
-const MOCK_CONVERSATIONS: Conversation[] = [
-  {
-    id: 'conv-1',
-    participants: [
-      { id: 'user-1', displayName: 'Maija M.' },
-      { id: 'user-2', displayName: 'Pekka P.' },
-    ],
-    context: {
-      type: 'friend_request',
-      friendRequest: {
-        id: 'fr-1',
-        childName: 'Emma',
-        childAge: 5,
-      },
-    },
-    lastMessage: {
-      content: 'Hei! Olisiko teillä aikaa leikkiä huomenna puistossa?',
-      senderId: 'user-2',
-      createdAt: new Date(Date.now() - 1000 * 60 * 5), // 5 min ago
-    },
-    unreadCount: 2,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
-    updatedAt: new Date(Date.now() - 1000 * 60 * 5),
-  },
-  {
-    id: 'conv-2',
-    participants: [
-      { id: 'user-1', displayName: 'Maija M.' },
-      { id: 'user-3', displayName: 'Anna K.' },
-    ],
-    context: {
-      type: 'playtime',
-      playtime: {
-        id: 'pt-1',
-        playgroundName: 'Kariniemen leikkipuisto',
-        scheduledTime: new Date(Date.now() + 1000 * 60 * 60 * 2), // 2 hours from now
-        duration: 60,
-      },
-    },
-    lastMessage: {
-      content: 'Nähdään siellä! Meillä on mukana jalkapallo.',
-      senderId: 'user-1',
-      createdAt: new Date(Date.now() - 1000 * 60 * 30), // 30 min ago
-    },
-    unreadCount: 0,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3),
-    updatedAt: new Date(Date.now() - 1000 * 60 * 30),
-  },
-  {
-    id: 'conv-3',
-    participants: [
-      { id: 'user-1', displayName: 'Maija M.' },
-      { id: 'user-4', displayName: 'Mikko T.' },
-    ],
-    context: {
-      type: 'general',
-      topic: 'Leikkipuistot',
-    },
-    lastMessage: {
-      content: 'Kiitos vinkistä! Käydään testaamassa ensi viikolla.',
-      senderId: 'user-4',
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2), // 2 hours ago
-    },
-    unreadCount: 1,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
-  },
-  {
-    id: 'conv-4',
-    participants: [
-      { id: 'user-1', displayName: 'Maija M.' },
-      { id: 'user-5', displayName: 'Liisa H.' },
-    ],
-    context: {
-      type: 'friend_request',
-      friendRequest: {
-        id: 'fr-2',
-        childName: 'Onni',
-        childAge: 4,
-      },
-    },
-    lastMessage: {
-      content: 'Meillä olisi kiva tutustua! Lapset ovat saman ikäisiä.',
-      senderId: 'user-5',
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
-    },
-    unreadCount: 0,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2),
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
-  },
-];
-
-const MOCK_MESSAGES: Record<string, Message[]> = {
-  'conv-1': [
-    {
-      id: 'msg-1-1',
-      conversationId: 'conv-1',
-      senderId: 'user-2',
-      senderName: 'Pekka P.',
-      content: 'Hei! Näin ilmoituksesi kaverihausta.',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
-    },
-    {
-      id: 'msg-1-2',
-      conversationId: 'conv-1',
-      senderId: 'user-1',
-      senderName: 'Maija M.',
-      content: 'Hei Pekka! Kiva kuulla. Minkä ikäinen teidän lapsi on?',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 23),
-    },
-    {
-      id: 'msg-1-3',
-      conversationId: 'conv-1',
-      senderId: 'user-2',
-      senderName: 'Pekka P.',
-      content: 'Meidän Eemil on 5-vuotias, tykkää jalkapallosta!',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 22),
-    },
-    {
-      id: 'msg-1-4',
-      conversationId: 'conv-1',
-      senderId: 'user-2',
-      senderName: 'Pekka P.',
-      content: 'Hei! Olisiko teillä aikaa leikkiä huomenna puistossa?',
-      read: false,
-      createdAt: new Date(Date.now() - 1000 * 60 * 5),
-    },
-  ],
-  'conv-2': [
-    {
-      id: 'msg-2-1',
-      conversationId: 'conv-2',
-      senderId: 'user-3',
-      senderName: 'Anna K.',
-      content: 'Hei! Nähdäänkö Kariniemessä klo 14?',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60),
-    },
-    {
-      id: 'msg-2-2',
-      conversationId: 'conv-2',
-      senderId: 'user-1',
-      senderName: 'Maija M.',
-      content: 'Sopii hyvin! Nähdään siellä.',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 45),
-    },
-    {
-      id: 'msg-2-3',
-      conversationId: 'conv-2',
-      senderId: 'user-1',
-      senderName: 'Maija M.',
-      content: 'Nähdään siellä! Meillä on mukana jalkapallo.',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 30),
-    },
-  ],
-  'conv-3': [
-    {
-      id: 'msg-3-1',
-      conversationId: 'conv-3',
-      senderId: 'user-1',
-      senderName: 'Maija M.',
-      content: 'Oletko käynyt Launeen leikkipuistossa? Siellä on uudet kiipeilytelineet!',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3),
-    },
-    {
-      id: 'msg-3-2',
-      conversationId: 'conv-3',
-      senderId: 'user-4',
-      senderName: 'Mikko T.',
-      content: 'Kiitos vinkistä! Käydään testaamassa ensi viikolla.',
-      read: false,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
-    },
-  ],
-  'conv-4': [
-    {
-      id: 'msg-4-1',
-      conversationId: 'conv-4',
-      senderId: 'user-5',
-      senderName: 'Liisa H.',
-      content: 'Meillä olisi kiva tutustua! Lapset ovat saman ikäisiä.',
-      read: true,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
-    },
-  ],
-};
-
 @Injectable({
   providedIn: 'root',
 })
 export class MessageService {
   private readonly http = inject(HttpClient);
   private readonly apiUrl = `${environment.apiUrl}/conversations`;
-  private readonly useMockData = !environment.production;
 
   private conversationsSubject = new BehaviorSubject<Conversation[]>([]);
   conversations$ = this.conversationsSubject.asObservable();
@@ -222,15 +27,6 @@ export class MessageService {
    * Get all conversations for current user
    */
   getConversations(): Observable<Conversation[]> {
-    if (this.useMockData) {
-      return of(MOCK_CONVERSATIONS).pipe(
-        tap((conversations) => {
-          this.conversationsSubject.next(conversations);
-          this.updateUnreadCount(conversations);
-        })
-      );
-    }
-
     return this.http.get<Conversation[]>(this.apiUrl).pipe(
       map((conversations) => this.convertConversationDates(conversations)),
       tap((conversations) => {
@@ -244,11 +40,6 @@ export class MessageService {
    * Get single conversation by ID
    */
   getConversation(id: string): Observable<Conversation> {
-    if (this.useMockData) {
-      const conversation = MOCK_CONVERSATIONS.find((c) => c.id === id);
-      return of(conversation!);
-    }
-
     return this.http.get<Conversation>(`${this.apiUrl}/${id}`).pipe(
       map((conversation) => this.convertSingleConversationDates(conversation))
     );
@@ -258,10 +49,6 @@ export class MessageService {
    * Create a new conversation
    */
   createConversation(dto: CreateConversationDto): Observable<Conversation> {
-    if (this.useMockData) {
-      return of(MOCK_CONVERSATIONS[0]);
-    }
-
     const payload = {
       participant_id: dto.participantId,
       context_type: dto.contextType,
@@ -282,11 +69,6 @@ export class MessageService {
     contextType?: ConversationContextType,
     contextId?: string
   ): Observable<Conversation> {
-    if (this.useMockData) {
-      return of(MOCK_CONVERSATIONS[0]);
-    }
-
-    // Try to find existing conversation first
     const payload = {
       participant_id: participantId,
       context_type: contextType,
@@ -301,14 +83,9 @@ export class MessageService {
   /**
    * Get messages for a conversation
    */
-  getMessages(conversationId: string, _cursor?: string): Observable<Message[]> {
-    if (this.useMockData) {
-      const messages = MOCK_MESSAGES[conversationId] || [];
-      return of(messages);
-    }
-
-    const url = _cursor
-      ? `${this.apiUrl}/${conversationId}/messages?cursor=${_cursor}`
+  getMessages(conversationId: string, cursor?: string): Observable<Message[]> {
+    const url = cursor
+      ? `${this.apiUrl}/${conversationId}/messages?cursor=${cursor}`
       : `${this.apiUrl}/${conversationId}/messages`;
 
     return this.http.get<Message[]>(url).pipe(
@@ -320,19 +97,6 @@ export class MessageService {
    * Send a message in a conversation
    */
   sendMessage(conversationId: string, dto: CreateMessageDto): Observable<Message> {
-    if (this.useMockData) {
-      const newMessage: Message = {
-        id: `msg-${Date.now()}`,
-        conversationId,
-        senderId: 'user-1',
-        senderName: 'Maija M.',
-        content: dto.content,
-        read: true,
-        createdAt: new Date(),
-      };
-      return of(newMessage);
-    }
-
     return this.http
       .post<Message>(`${this.apiUrl}/${conversationId}/messages`, dto)
       .pipe(
@@ -348,16 +112,6 @@ export class MessageService {
    * Mark all messages in a conversation as read
    */
   markAsRead(conversationId: string): Observable<void> {
-    if (this.useMockData) {
-      // Update local mock data to clear unread count
-      const conversations = this.conversationsSubject.getValue();
-      const updatedConversations = conversations.map((c) =>
-        c.id === conversationId ? { ...c, unreadCount: 0 } : c
-      );
-      this.conversationsSubject.next(updatedConversations);
-      return of(undefined);
-    }
-
     return this.http
       .post<void>(`${this.apiUrl}/${conversationId}/read`, {})
       .pipe(tap(() => this.refreshConversations()));
@@ -367,11 +121,6 @@ export class MessageService {
    * Get total unread message count
    */
   getUnreadCount(): Observable<number> {
-    if (this.useMockData) {
-      const total = MOCK_CONVERSATIONS.reduce((sum, c) => sum + c.unreadCount, 0);
-      return of(total).pipe(tap((count) => this.unreadCountSubject.next(count)));
-    }
-
     return this.http.get<{ count: number }>(`${environment.apiUrl}/messages/unread-count`).pipe(
       map((response) => response.count),
       tap((count) => this.unreadCountSubject.next(count))
@@ -382,12 +131,6 @@ export class MessageService {
    * Refresh conversations after mutations
    */
   refreshConversations(): void {
-    if (this.useMockData) {
-      this.conversationsSubject.next(MOCK_CONVERSATIONS);
-      this.updateUnreadCount(MOCK_CONVERSATIONS);
-      return;
-    }
-
     this.http
       .get<Conversation[]>(this.apiUrl)
       .pipe(map((conversations) => this.convertConversationDates(conversations)))

--- a/src/app/shared/services/message.service.ts
+++ b/src/app/shared/services/message.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, BehaviorSubject, tap, map } from 'rxjs';
+import { Observable, BehaviorSubject, tap, map, of } from 'rxjs';
 import {
   Conversation,
   Message,
@@ -10,12 +10,207 @@ import {
 } from '../models/message.model';
 import { environment } from '../../../environments/environment';
 
+// Mock data for local development
+const MOCK_CONVERSATIONS: Conversation[] = [
+  {
+    id: 'conv-1',
+    participants: [
+      { id: 'user-1', displayName: 'Maija M.' },
+      { id: 'user-2', displayName: 'Pekka P.' },
+    ],
+    context: {
+      type: 'friend_request',
+      friendRequest: {
+        id: 'fr-1',
+        childName: 'Emma',
+        childAge: 5,
+      },
+    },
+    lastMessage: {
+      content: 'Hei! Olisiko teillä aikaa leikkiä huomenna puistossa?',
+      senderId: 'user-2',
+      createdAt: new Date(Date.now() - 1000 * 60 * 5), // 5 min ago
+    },
+    unreadCount: 2,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+    updatedAt: new Date(Date.now() - 1000 * 60 * 5),
+  },
+  {
+    id: 'conv-2',
+    participants: [
+      { id: 'user-1', displayName: 'Maija M.' },
+      { id: 'user-3', displayName: 'Anna K.' },
+    ],
+    context: {
+      type: 'playtime',
+      playtime: {
+        id: 'pt-1',
+        playgroundName: 'Kariniemen leikkipuisto',
+        scheduledTime: new Date(Date.now() + 1000 * 60 * 60 * 2), // 2 hours from now
+        duration: 60,
+      },
+    },
+    lastMessage: {
+      content: 'Nähdään siellä! Meillä on mukana jalkapallo.',
+      senderId: 'user-1',
+      createdAt: new Date(Date.now() - 1000 * 60 * 30), // 30 min ago
+    },
+    unreadCount: 0,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 30),
+  },
+  {
+    id: 'conv-3',
+    participants: [
+      { id: 'user-1', displayName: 'Maija M.' },
+      { id: 'user-4', displayName: 'Mikko T.' },
+    ],
+    context: {
+      type: 'general',
+      topic: 'Leikkipuistot',
+    },
+    lastMessage: {
+      content: 'Kiitos vinkistä! Käydään testaamassa ensi viikolla.',
+      senderId: 'user-4',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2), // 2 hours ago
+    },
+    unreadCount: 1,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
+  },
+  {
+    id: 'conv-4',
+    participants: [
+      { id: 'user-1', displayName: 'Maija M.' },
+      { id: 'user-5', displayName: 'Liisa H.' },
+    ],
+    context: {
+      type: 'friend_request',
+      friendRequest: {
+        id: 'fr-2',
+        childName: 'Onni',
+        childAge: 4,
+      },
+    },
+    lastMessage: {
+      content: 'Meillä olisi kiva tutustua! Lapset ovat saman ikäisiä.',
+      senderId: 'user-5',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+    },
+    unreadCount: 0,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
+  },
+];
+
+const MOCK_MESSAGES: Record<string, Message[]> = {
+  'conv-1': [
+    {
+      id: 'msg-1-1',
+      conversationId: 'conv-1',
+      senderId: 'user-2',
+      senderName: 'Pekka P.',
+      content: 'Hei! Näin ilmoituksesi kaverihausta.',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    },
+    {
+      id: 'msg-1-2',
+      conversationId: 'conv-1',
+      senderId: 'user-1',
+      senderName: 'Maija M.',
+      content: 'Hei Pekka! Kiva kuulla. Minkä ikäinen teidän lapsi on?',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 23),
+    },
+    {
+      id: 'msg-1-3',
+      conversationId: 'conv-1',
+      senderId: 'user-2',
+      senderName: 'Pekka P.',
+      content: 'Meidän Eemil on 5-vuotias, tykkää jalkapallosta!',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 22),
+    },
+    {
+      id: 'msg-1-4',
+      conversationId: 'conv-1',
+      senderId: 'user-2',
+      senderName: 'Pekka P.',
+      content: 'Hei! Olisiko teillä aikaa leikkiä huomenna puistossa?',
+      read: false,
+      createdAt: new Date(Date.now() - 1000 * 60 * 5),
+    },
+  ],
+  'conv-2': [
+    {
+      id: 'msg-2-1',
+      conversationId: 'conv-2',
+      senderId: 'user-3',
+      senderName: 'Anna K.',
+      content: 'Hei! Nähdäänkö Kariniemessä klo 14?',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60),
+    },
+    {
+      id: 'msg-2-2',
+      conversationId: 'conv-2',
+      senderId: 'user-1',
+      senderName: 'Maija M.',
+      content: 'Sopii hyvin! Nähdään siellä.',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 45),
+    },
+    {
+      id: 'msg-2-3',
+      conversationId: 'conv-2',
+      senderId: 'user-1',
+      senderName: 'Maija M.',
+      content: 'Nähdään siellä! Meillä on mukana jalkapallo.',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 30),
+    },
+  ],
+  'conv-3': [
+    {
+      id: 'msg-3-1',
+      conversationId: 'conv-3',
+      senderId: 'user-1',
+      senderName: 'Maija M.',
+      content: 'Oletko käynyt Launeen leikkipuistossa? Siellä on uudet kiipeilytelineet!',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3),
+    },
+    {
+      id: 'msg-3-2',
+      conversationId: 'conv-3',
+      senderId: 'user-4',
+      senderName: 'Mikko T.',
+      content: 'Kiitos vinkistä! Käydään testaamassa ensi viikolla.',
+      read: false,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
+    },
+  ],
+  'conv-4': [
+    {
+      id: 'msg-4-1',
+      conversationId: 'conv-4',
+      senderId: 'user-5',
+      senderName: 'Liisa H.',
+      content: 'Meillä olisi kiva tutustua! Lapset ovat saman ikäisiä.',
+      read: true,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    },
+  ],
+};
+
 @Injectable({
   providedIn: 'root',
 })
 export class MessageService {
-  private http = inject(HttpClient);
-  private apiUrl = `${environment.apiUrl}/conversations`;
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = `${environment.apiUrl}/conversations`;
+  private readonly useMockData = !environment.production;
 
   private conversationsSubject = new BehaviorSubject<Conversation[]>([]);
   conversations$ = this.conversationsSubject.asObservable();
@@ -23,14 +218,19 @@ export class MessageService {
   private unreadCountSubject = new BehaviorSubject<number>(0);
   unreadCount$ = this.unreadCountSubject.asObservable();
 
-  constructor() {
-    // Initial load is triggered when user is authenticated
-  }
-
   /**
    * Get all conversations for current user
    */
   getConversations(): Observable<Conversation[]> {
+    if (this.useMockData) {
+      return of(MOCK_CONVERSATIONS).pipe(
+        tap((conversations) => {
+          this.conversationsSubject.next(conversations);
+          this.updateUnreadCount(conversations);
+        })
+      );
+    }
+
     return this.http.get<Conversation[]>(this.apiUrl).pipe(
       map((conversations) => this.convertConversationDates(conversations)),
       tap((conversations) => {
@@ -44,6 +244,11 @@ export class MessageService {
    * Get single conversation by ID
    */
   getConversation(id: string): Observable<Conversation> {
+    if (this.useMockData) {
+      const conversation = MOCK_CONVERSATIONS.find((c) => c.id === id);
+      return of(conversation!);
+    }
+
     return this.http.get<Conversation>(`${this.apiUrl}/${id}`).pipe(
       map((conversation) => this.convertSingleConversationDates(conversation))
     );
@@ -53,6 +258,10 @@ export class MessageService {
    * Create a new conversation
    */
   createConversation(dto: CreateConversationDto): Observable<Conversation> {
+    if (this.useMockData) {
+      return of(MOCK_CONVERSATIONS[0]);
+    }
+
     const payload = {
       participant_id: dto.participantId,
       context_type: dto.contextType,
@@ -73,6 +282,10 @@ export class MessageService {
     contextType?: ConversationContextType,
     contextId?: string
   ): Observable<Conversation> {
+    if (this.useMockData) {
+      return of(MOCK_CONVERSATIONS[0]);
+    }
+
     // Try to find existing conversation first
     const payload = {
       participant_id: participantId,
@@ -88,9 +301,14 @@ export class MessageService {
   /**
    * Get messages for a conversation
    */
-  getMessages(conversationId: string, cursor?: string): Observable<Message[]> {
-    const url = cursor
-      ? `${this.apiUrl}/${conversationId}/messages?cursor=${cursor}`
+  getMessages(conversationId: string, _cursor?: string): Observable<Message[]> {
+    if (this.useMockData) {
+      const messages = MOCK_MESSAGES[conversationId] || [];
+      return of(messages);
+    }
+
+    const url = _cursor
+      ? `${this.apiUrl}/${conversationId}/messages?cursor=${_cursor}`
       : `${this.apiUrl}/${conversationId}/messages`;
 
     return this.http.get<Message[]>(url).pipe(
@@ -102,6 +320,19 @@ export class MessageService {
    * Send a message in a conversation
    */
   sendMessage(conversationId: string, dto: CreateMessageDto): Observable<Message> {
+    if (this.useMockData) {
+      const newMessage: Message = {
+        id: `msg-${Date.now()}`,
+        conversationId,
+        senderId: 'user-1',
+        senderName: 'Maija M.',
+        content: dto.content,
+        read: true,
+        createdAt: new Date(),
+      };
+      return of(newMessage);
+    }
+
     return this.http
       .post<Message>(`${this.apiUrl}/${conversationId}/messages`, dto)
       .pipe(
@@ -117,6 +348,10 @@ export class MessageService {
    * Mark all messages in a conversation as read
    */
   markAsRead(conversationId: string): Observable<void> {
+    if (this.useMockData) {
+      return of(undefined);
+    }
+
     return this.http
       .post<void>(`${this.apiUrl}/${conversationId}/read`, {})
       .pipe(tap(() => this.refreshConversations()));
@@ -126,6 +361,11 @@ export class MessageService {
    * Get total unread message count
    */
   getUnreadCount(): Observable<number> {
+    if (this.useMockData) {
+      const total = MOCK_CONVERSATIONS.reduce((sum, c) => sum + c.unreadCount, 0);
+      return of(total).pipe(tap((count) => this.unreadCountSubject.next(count)));
+    }
+
     return this.http.get<{ count: number }>(`${environment.apiUrl}/messages/unread-count`).pipe(
       map((response) => response.count),
       tap((count) => this.unreadCountSubject.next(count))
@@ -136,6 +376,12 @@ export class MessageService {
    * Refresh conversations after mutations
    */
   refreshConversations(): void {
+    if (this.useMockData) {
+      this.conversationsSubject.next(MOCK_CONVERSATIONS);
+      this.updateUnreadCount(MOCK_CONVERSATIONS);
+      return;
+    }
+
     this.http
       .get<Conversation[]>(this.apiUrl)
       .pipe(map((conversations) => this.convertConversationDates(conversations)))

--- a/src/app/shared/services/message.service.ts
+++ b/src/app/shared/services/message.service.ts
@@ -1,0 +1,203 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, BehaviorSubject, tap, map } from 'rxjs';
+import {
+  Conversation,
+  Message,
+  CreateMessageDto,
+  CreateConversationDto,
+  ConversationContextType,
+} from '../models/message.model';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MessageService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/conversations`;
+
+  private conversationsSubject = new BehaviorSubject<Conversation[]>([]);
+  conversations$ = this.conversationsSubject.asObservable();
+
+  private unreadCountSubject = new BehaviorSubject<number>(0);
+  unreadCount$ = this.unreadCountSubject.asObservable();
+
+  constructor() {
+    // Initial load is triggered when user is authenticated
+  }
+
+  /**
+   * Get all conversations for current user
+   */
+  getConversations(): Observable<Conversation[]> {
+    return this.http.get<Conversation[]>(this.apiUrl).pipe(
+      map((conversations) => this.convertConversationDates(conversations)),
+      tap((conversations) => {
+        this.conversationsSubject.next(conversations);
+        this.updateUnreadCount(conversations);
+      })
+    );
+  }
+
+  /**
+   * Get single conversation by ID
+   */
+  getConversation(id: string): Observable<Conversation> {
+    return this.http.get<Conversation>(`${this.apiUrl}/${id}`).pipe(
+      map((conversation) => this.convertSingleConversationDates(conversation))
+    );
+  }
+
+  /**
+   * Create a new conversation
+   */
+  createConversation(dto: CreateConversationDto): Observable<Conversation> {
+    const payload = {
+      participant_id: dto.participantId,
+      context_type: dto.contextType,
+      context_id: dto.contextId,
+      custom_topic: dto.customTopic,
+    };
+    return this.http.post<Conversation>(this.apiUrl, payload).pipe(
+      map((conversation) => this.convertSingleConversationDates(conversation)),
+      tap(() => this.refreshConversations())
+    );
+  }
+
+  /**
+   * Find or create conversation for a specific context
+   */
+  getOrCreateConversation(
+    participantId: string,
+    contextType?: ConversationContextType,
+    contextId?: string
+  ): Observable<Conversation> {
+    // Try to find existing conversation first
+    const payload = {
+      participant_id: participantId,
+      context_type: contextType,
+      context_id: contextId,
+    };
+    return this.http.post<Conversation>(`${this.apiUrl}/find-or-create`, payload).pipe(
+      map((conversation) => this.convertSingleConversationDates(conversation)),
+      tap(() => this.refreshConversations())
+    );
+  }
+
+  /**
+   * Get messages for a conversation
+   */
+  getMessages(conversationId: string, cursor?: string): Observable<Message[]> {
+    const url = cursor
+      ? `${this.apiUrl}/${conversationId}/messages?cursor=${cursor}`
+      : `${this.apiUrl}/${conversationId}/messages`;
+
+    return this.http.get<Message[]>(url).pipe(
+      map((messages) => this.convertMessageDates(messages))
+    );
+  }
+
+  /**
+   * Send a message in a conversation
+   */
+  sendMessage(conversationId: string, dto: CreateMessageDto): Observable<Message> {
+    return this.http
+      .post<Message>(`${this.apiUrl}/${conversationId}/messages`, dto)
+      .pipe(
+        map((message) => ({
+          ...message,
+          createdAt: new Date(message.createdAt),
+        })),
+        tap(() => this.refreshConversations())
+      );
+  }
+
+  /**
+   * Mark all messages in a conversation as read
+   */
+  markAsRead(conversationId: string): Observable<void> {
+    return this.http
+      .post<void>(`${this.apiUrl}/${conversationId}/read`, {})
+      .pipe(tap(() => this.refreshConversations()));
+  }
+
+  /**
+   * Get total unread message count
+   */
+  getUnreadCount(): Observable<number> {
+    return this.http.get<{ count: number }>(`${environment.apiUrl}/messages/unread-count`).pipe(
+      map((response) => response.count),
+      tap((count) => this.unreadCountSubject.next(count))
+    );
+  }
+
+  /**
+   * Refresh conversations after mutations
+   */
+  refreshConversations(): void {
+    this.http
+      .get<Conversation[]>(this.apiUrl)
+      .pipe(map((conversations) => this.convertConversationDates(conversations)))
+      .subscribe({
+        next: (conversations) => {
+          this.conversationsSubject.next(conversations);
+          this.updateUnreadCount(conversations);
+        },
+        error: (error) => console.error('Error loading conversations:', error),
+      });
+  }
+
+  /**
+   * Convert date strings to Date objects for conversations array
+   */
+  private convertConversationDates(conversations: Conversation[]): Conversation[] {
+    return conversations.map((conv) => this.convertSingleConversationDates(conv));
+  }
+
+  /**
+   * Convert date strings to Date objects for a single conversation
+   */
+  private convertSingleConversationDates(conversation: Conversation): Conversation {
+    return {
+      ...conversation,
+      createdAt: new Date(conversation.createdAt),
+      updatedAt: new Date(conversation.updatedAt),
+      lastMessage: conversation.lastMessage
+        ? {
+            ...conversation.lastMessage,
+            createdAt: new Date(conversation.lastMessage.createdAt),
+          }
+        : undefined,
+      context: conversation.context
+        ? {
+            ...conversation.context,
+            playtime: conversation.context.playtime
+              ? {
+                  ...conversation.context.playtime,
+                  scheduledTime: new Date(conversation.context.playtime.scheduledTime),
+                }
+              : undefined,
+          }
+        : undefined,
+    };
+  }
+
+  /**
+   * Convert date strings to Date objects for messages array
+   */
+  private convertMessageDates(messages: Message[]): Message[] {
+    return messages.map((message) => ({
+      ...message,
+      createdAt: new Date(message.createdAt),
+    }));
+  }
+
+  /**
+   * Update unread count from conversations
+   */
+  private updateUnreadCount(conversations: Conversation[]): void {
+    const total = conversations.reduce((sum, conv) => sum + conv.unreadCount, 0);
+    this.unreadCountSubject.next(total);
+  }
+}

--- a/src/app/shared/services/message.service.ts
+++ b/src/app/shared/services/message.service.ts
@@ -349,6 +349,12 @@ export class MessageService {
    */
   markAsRead(conversationId: string): Observable<void> {
     if (this.useMockData) {
+      // Update local mock data to clear unread count
+      const conversations = this.conversationsSubject.getValue();
+      const updatedConversations = conversations.map((c) =>
+        c.id === conversationId ? { ...c, unreadCount: 0 } : c
+      );
+      this.conversationsSubject.next(updatedConversations);
       return of(undefined);
     }
 

--- a/src/app/shared/styles/_page-layout.scss
+++ b/src/app/shared/styles/_page-layout.scss
@@ -1,0 +1,102 @@
+// Shared page layout styles for consistent container and state styling
+
+// Page container - wraps full page content with max-width
+%page-container {
+  min-height: calc(100vh - 4rem);
+  background-color: #f5f5f5;
+  position: relative;
+}
+
+// Content container - max-width centered content
+%content-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+}
+
+// Loading state - centered spinner
+%loading-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 25rem;
+  gap: 1rem;
+  color: #666;
+}
+
+// Empty state - centered message with icon
+%empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+
+  .empty-icon,
+  mat-icon,
+  .material-icons {
+    font-size: 4rem;
+    width: 4rem;
+    height: 4rem;
+    color: rgba(0, 0, 0, 0.3);
+    margin-bottom: 1rem;
+  }
+
+  h2, h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.87);
+  }
+
+  p {
+    margin: 0 0 1.5rem 0;
+    font-size: 0.875rem;
+    max-width: 20rem;
+  }
+}
+
+// Grid layout for cards
+%card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15.625rem, 1fr));
+  gap: 1.5rem;
+
+  @media (min-width: 769px) {
+    // Limit to max 4 columns on desktop
+    grid-template-columns: repeat(auto-fill, minmax(max(15.625rem, calc((100% - 4.5rem) / 4)), 1fr));
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+// Mixin versions for direct use
+@mixin page-container {
+  @extend %page-container;
+}
+
+@mixin content-container {
+  @extend %content-container;
+}
+
+@mixin loading-container {
+  @extend %loading-container;
+}
+
+@mixin empty-state {
+  @extend %empty-state;
+}
+
+@mixin card-grid {
+  @extend %card-grid;
+}

--- a/src/app/shared/utils/conversation.helpers.spec.ts
+++ b/src/app/shared/utils/conversation.helpers.spec.ts
@@ -1,0 +1,285 @@
+import {
+  sortConversations,
+  getConversationDisplayInfo,
+  formatConversationTimestamp,
+} from './conversation.helpers';
+import { Conversation } from '../models/message.model';
+
+describe('Conversation Helpers', () => {
+  describe('sortConversations', () => {
+    const createConversation = (
+      id: string,
+      unreadCount: number,
+      lastMessageTime: Date | null,
+      createdAt: Date
+    ): Conversation => ({
+      id,
+      participants: [],
+      unreadCount,
+      lastMessage: lastMessageTime
+        ? { content: 'test', senderId: '1', createdAt: lastMessageTime }
+        : undefined,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    it('should place unread conversations before read conversations', () => {
+      const now = new Date();
+      const conversations: Conversation[] = [
+        createConversation('read1', 0, now, now),
+        createConversation('unread1', 2, now, now),
+        createConversation('read2', 0, now, now),
+      ];
+
+      const sorted = sortConversations(conversations);
+
+      expect(sorted[0].id).toBe('unread1');
+      expect(sorted[1].id).toBe('read1');
+      expect(sorted[2].id).toBe('read2');
+    });
+
+    it('should sort unread conversations by most recent message first', () => {
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 3600000);
+      const twoHoursAgo = new Date(now.getTime() - 7200000);
+
+      const conversations: Conversation[] = [
+        createConversation('unread-old', 1, twoHoursAgo, twoHoursAgo),
+        createConversation('unread-new', 1, now, now),
+        createConversation('unread-mid', 1, oneHourAgo, oneHourAgo),
+      ];
+
+      const sorted = sortConversations(conversations);
+
+      expect(sorted[0].id).toBe('unread-new');
+      expect(sorted[1].id).toBe('unread-mid');
+      expect(sorted[2].id).toBe('unread-old');
+    });
+
+    it('should sort read conversations by most recent message first', () => {
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 3600000);
+      const twoHoursAgo = new Date(now.getTime() - 7200000);
+
+      const conversations: Conversation[] = [
+        createConversation('read-old', 0, twoHoursAgo, twoHoursAgo),
+        createConversation('read-new', 0, now, now),
+        createConversation('read-mid', 0, oneHourAgo, oneHourAgo),
+      ];
+
+      const sorted = sortConversations(conversations);
+
+      expect(sorted[0].id).toBe('read-new');
+      expect(sorted[1].id).toBe('read-mid');
+      expect(sorted[2].id).toBe('read-old');
+    });
+
+    it('should use createdAt when lastMessage is not available', () => {
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 3600000);
+
+      const conversations: Conversation[] = [
+        createConversation('old', 0, null, oneHourAgo),
+        createConversation('new', 0, null, now),
+      ];
+
+      const sorted = sortConversations(conversations);
+
+      expect(sorted[0].id).toBe('new');
+      expect(sorted[1].id).toBe('old');
+    });
+
+    it('should return empty array for empty input', () => {
+      expect(sortConversations([])).toEqual([]);
+    });
+
+    it('should handle mixed unread and read with proper ordering', () => {
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 3600000);
+      const twoHoursAgo = new Date(now.getTime() - 7200000);
+      const threeHoursAgo = new Date(now.getTime() - 10800000);
+
+      const conversations: Conversation[] = [
+        createConversation('read-recent', 0, oneHourAgo, oneHourAgo),
+        createConversation('unread-old', 3, threeHoursAgo, threeHoursAgo),
+        createConversation('read-old', 0, twoHoursAgo, twoHoursAgo),
+        createConversation('unread-recent', 1, now, now),
+      ];
+
+      const sorted = sortConversations(conversations);
+
+      // Unread first (sorted by time)
+      expect(sorted[0].id).toBe('unread-recent');
+      expect(sorted[1].id).toBe('unread-old');
+      // Then read (sorted by time)
+      expect(sorted[2].id).toBe('read-recent');
+      expect(sorted[3].id).toBe('read-old');
+    });
+  });
+
+  describe('getConversationDisplayInfo', () => {
+    const createBaseConversation = (): Conversation => ({
+      id: '1',
+      participants: [
+        { id: 'user1', displayName: 'Maija M.' },
+        { id: 'user2', displayName: 'Pekka P.' },
+      ],
+      unreadCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    it('should return playtime display info for playtime context', () => {
+      const conversation: Conversation = {
+        ...createBaseConversation(),
+        context: {
+          type: 'playtime',
+          playtime: {
+            id: 'pt1',
+            playgroundName: 'Kariniemen leikkipuisto',
+            scheduledTime: new Date(),
+            duration: 60,
+          },
+        },
+      };
+
+      const result = getConversationDisplayInfo(conversation, 'user1');
+
+      expect(result.icon).toBe('place');
+      expect(result.title).toContain('Kariniemen leikkipuisto');
+      expect(result.subtitle).toBe('Pekka P.');
+    });
+
+    it('should return friend request display info for friend_request context', () => {
+      const conversation: Conversation = {
+        ...createBaseConversation(),
+        context: {
+          type: 'friend_request',
+          friendRequest: {
+            id: 'fr1',
+            childName: 'Matti',
+            childAge: 5,
+          },
+        },
+      };
+
+      const result = getConversationDisplayInfo(conversation, 'user1');
+
+      expect(result.icon).toBe('person_search');
+      expect(result.title).toBe('Kaverihausta: Matti, 5v');
+      expect(result.subtitle).toBe('Pekka P.');
+    });
+
+    it('should return general display info for general context', () => {
+      const conversation: Conversation = {
+        ...createBaseConversation(),
+        context: {
+          type: 'general',
+          topic: 'Leikkipuistot',
+        },
+      };
+
+      const result = getConversationDisplayInfo(conversation, 'user1');
+
+      expect(result.icon).toBe('person');
+      expect(result.title).toBe('Pekka P.');
+      expect(result.subtitle).toBe('Leikkipuistot');
+    });
+
+    it('should return other participant name for conversations without context', () => {
+      const conversation = createBaseConversation();
+
+      const result = getConversationDisplayInfo(conversation, 'user1');
+
+      expect(result.icon).toBe('person');
+      expect(result.title).toBe('Pekka P.');
+      expect(result.subtitle).toBeUndefined();
+    });
+
+    it('should return "Tuntematon" when other participant is not found', () => {
+      const conversation: Conversation = {
+        ...createBaseConversation(),
+        participants: [{ id: 'user1', displayName: 'Maija M.' }],
+      };
+
+      const result = getConversationDisplayInfo(conversation, 'user1');
+
+      expect(result.title).toBe('Tuntematon');
+    });
+
+    it('should handle undefined currentUserId', () => {
+      const conversation = createBaseConversation();
+
+      const result = getConversationDisplayInfo(conversation, undefined);
+
+      // Should return first participant since none match undefined
+      expect(result.title).toBe('Maija M.');
+    });
+  });
+
+  describe('formatConversationTimestamp', () => {
+    it('should return "Nyt" for dates less than 1 minute ago', () => {
+      const now = new Date();
+      const thirtySecondsAgo = new Date(now.getTime() - 30000);
+
+      expect(formatConversationTimestamp(thirtySecondsAgo)).toBe('Nyt');
+    });
+
+    it('should return minutes for dates less than 60 minutes ago', () => {
+      const now = new Date();
+      const fiveMinutesAgo = new Date(now.getTime() - 5 * 60000);
+
+      expect(formatConversationTimestamp(fiveMinutesAgo)).toBe('5 min');
+    });
+
+    it('should return "Eilen" for yesterday', () => {
+      const now = new Date();
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(12, 0, 0, 0);
+
+      expect(formatConversationTimestamp(yesterday)).toBe('Eilen');
+    });
+
+    it('should return time for today but more than 60 minutes ago', () => {
+      const now = new Date();
+      const twoHoursAgo = new Date(now.getTime() - 2 * 3600000);
+
+      // Only test if it's still the same day
+      if (twoHoursAgo.toDateString() === now.toDateString()) {
+        const result = formatConversationTimestamp(twoHoursAgo);
+        // Should be in HH:MM format
+        expect(result).toMatch(/^\d{1,2}[.:]\d{2}$/);
+      }
+    });
+
+    it('should return weekday for dates within the last 7 days', () => {
+      const now = new Date();
+      const threeDaysAgo = new Date(now);
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      threeDaysAgo.setHours(12, 0, 0, 0);
+
+      const result = formatConversationTimestamp(threeDaysAgo);
+      // Should be a short weekday name in Finnish (e.g., "ma", "ti", "ke", etc.)
+      expect(result.length).toBeLessThanOrEqual(4);
+    });
+
+    it('should return date for dates older than 7 days', () => {
+      const now = new Date();
+      const tenDaysAgo = new Date(now);
+      tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+      const result = formatConversationTimestamp(tenDaysAgo);
+      // Should be in D.M. format
+      expect(result).toMatch(/^\d{1,2}\.\d{1,2}\.$/);
+    });
+
+    it('should handle string dates', () => {
+      const now = new Date();
+      const dateString = now.toISOString();
+
+      // Should not throw and should return "Nyt"
+      expect(() => formatConversationTimestamp(dateString as unknown as Date)).not.toThrow();
+    });
+  });
+});

--- a/src/app/shared/utils/conversation.helpers.ts
+++ b/src/app/shared/utils/conversation.helpers.ts
@@ -1,0 +1,102 @@
+import { Conversation } from '../models/message.model';
+
+export interface ConversationDisplayInfo {
+  title: string;
+  subtitle?: string;
+  icon: 'place' | 'person_search' | 'person';
+}
+
+/**
+ * Sort conversations WhatsApp-style:
+ * 1. Unread conversations first (sorted by most recent message)
+ * 2. Read conversations second (sorted by most recent message)
+ */
+export function sortConversations(conversations: Conversation[]): Conversation[] {
+  const unread = conversations.filter((c) => c.unreadCount > 0);
+  const read = conversations.filter((c) => c.unreadCount === 0);
+
+  const sortByTime = (a: Conversation, b: Conversation) => {
+    const timeA = a.lastMessage?.createdAt ?? a.createdAt;
+    const timeB = b.lastMessage?.createdAt ?? b.createdAt;
+    return new Date(timeB).getTime() - new Date(timeA).getTime();
+  };
+
+  return [...unread.sort(sortByTime), ...read.sort(sortByTime)];
+}
+
+export function getConversationDisplayInfo(
+  conversation: Conversation,
+  currentUserId: string | undefined
+): ConversationDisplayInfo {
+  const otherParticipant = conversation.participants.find((p) => p.id !== currentUserId);
+  const otherName = otherParticipant?.displayName || 'Tuntematon';
+
+  if (conversation.context?.type === 'playtime' && conversation.context.playtime) {
+    const pt = conversation.context.playtime;
+    return {
+      title: `${pt.playgroundName} - ${formatPlaytimeDate(pt.scheduledTime)}`,
+      subtitle: otherName,
+      icon: 'place',
+    };
+  }
+
+  if (conversation.context?.type === 'friend_request' && conversation.context.friendRequest) {
+    const fr = conversation.context.friendRequest;
+    return {
+      title: `Kaverihausta: ${fr.childName}, ${fr.childAge}v`,
+      subtitle: otherName,
+      icon: 'person_search',
+    };
+  }
+
+  return {
+    title: otherName,
+    subtitle: conversation.context?.topic,
+    icon: 'person',
+  };
+}
+
+function formatPlaytimeDate(date: Date): string {
+  const dateObj = date instanceof Date ? date : new Date(date);
+  const now = new Date();
+  const isToday = dateObj.toDateString() === now.toDateString();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const isTomorrow = dateObj.toDateString() === tomorrow.toDateString();
+
+  const time = dateObj.toLocaleTimeString('fi-FI', { hour: '2-digit', minute: '2-digit' });
+
+  if (isToday) return `Tänään ${time}`;
+  if (isTomorrow) return `Huomenna ${time}`;
+  return dateObj.toLocaleDateString('fi-FI', { day: 'numeric', month: 'numeric' }) + ` ${time}`;
+}
+
+/**
+ * Format timestamp for conversation list display
+ */
+export function formatConversationTimestamp(date: Date): string {
+  const dateObj = date instanceof Date ? date : new Date(date);
+  const now = new Date();
+  const diffMs = now.getTime() - dateObj.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Nyt';
+  if (diffMins < 60) return `${diffMins} min`;
+  if (diffHours < 24 && dateObj.toDateString() === now.toDateString()) {
+    return dateObj.toLocaleTimeString('fi-FI', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (dateObj.toDateString() === yesterday.toDateString()) {
+    return 'Eilen';
+  }
+
+  if (diffDays < 7) {
+    return dateObj.toLocaleDateString('fi-FI', { weekday: 'short' });
+  }
+
+  return dateObj.toLocaleDateString('fi-FI', { day: 'numeric', month: 'numeric' });
+}

--- a/src/app/shared/utils/index.ts
+++ b/src/app/shared/utils/index.ts
@@ -1,3 +1,5 @@
 // Barrel export for utilities
+export * from './conversation.helpers';
 export * from './generate-time-slots.helper';
+export * from './message-format.helper';
 export * from './string-array.helper';

--- a/src/app/shared/utils/message-format.helper.spec.ts
+++ b/src/app/shared/utils/message-format.helper.spec.ts
@@ -1,0 +1,154 @@
+import {
+  formatMessageContent,
+  stripMessageFormatting,
+  truncateMessage,
+} from './message-format.helper';
+
+describe('Message Format Helpers', () => {
+  describe('formatMessageContent', () => {
+    it('should convert *text* to <strong>text</strong>', () => {
+      const result = formatMessageContent('Hello *world*!');
+      expect(result).toContain('<strong>world</strong>');
+    });
+
+    it('should convert multiple bold markers', () => {
+      const result = formatMessageContent('*Hello* and *world*!');
+      expect(result).toContain('<strong>Hello</strong>');
+      expect(result).toContain('<strong>world</strong>');
+    });
+
+    it('should convert newlines to <br> tags', () => {
+      const result = formatMessageContent('Hello\nWorld');
+      expect(result).toContain('<br>');
+    });
+
+    it('should handle multiple newlines', () => {
+      const result = formatMessageContent('Line 1\n\nLine 3');
+      expect(result).toBe('Line 1<br><br>Line 3');
+    });
+
+    it('should escape HTML entities for security', () => {
+      const result = formatMessageContent('<script>alert("xss")</script>');
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('&lt;script&gt;');
+    });
+
+    it('should handle bold text with special characters inside', () => {
+      const result = formatMessageContent('*Hello & World*');
+      // The & should be escaped before bold conversion
+      expect(result).toContain('<strong>');
+      expect(result).toContain('</strong>');
+    });
+
+    it('should not convert single asterisks', () => {
+      const result = formatMessageContent('5 * 3 = 15');
+      expect(result).not.toContain('<strong>');
+    });
+
+    it('should handle empty string', () => {
+      expect(formatMessageContent('')).toBe('');
+    });
+
+    it('should handle plain text without formatting', () => {
+      const text = 'Hei! Nähdään puistossa.';
+      const result = formatMessageContent(text);
+      expect(result).toBe(text);
+    });
+
+    it('should handle combined formatting (bold and newlines)', () => {
+      const result = formatMessageContent('*Tärkeää*:\nOta mukaan pallo');
+      expect(result).toContain('<strong>Tärkeää</strong>');
+      expect(result).toContain('<br>');
+    });
+  });
+
+  describe('stripMessageFormatting', () => {
+    it('should remove bold markers', () => {
+      const result = stripMessageFormatting('Hello *world*!');
+      expect(result).toBe('Hello world!');
+    });
+
+    it('should remove multiple bold markers', () => {
+      const result = stripMessageFormatting('*Hello* and *world*!');
+      expect(result).toBe('Hello and world!');
+    });
+
+    it('should preserve newlines', () => {
+      const result = stripMessageFormatting('Hello\nWorld');
+      expect(result).toBe('Hello\nWorld');
+    });
+
+    it('should handle text without formatting', () => {
+      const text = 'Plain text message';
+      expect(stripMessageFormatting(text)).toBe(text);
+    });
+
+    it('should handle empty string', () => {
+      expect(stripMessageFormatting('')).toBe('');
+    });
+
+    it('should not remove single asterisks', () => {
+      const result = stripMessageFormatting('5 * 3 = 15');
+      expect(result).toBe('5 * 3 = 15');
+    });
+
+    it('should handle nested asterisks correctly', () => {
+      const result = stripMessageFormatting('*bold text*');
+      expect(result).toBe('bold text');
+    });
+  });
+
+  describe('truncateMessage', () => {
+    it('should return full message if shorter than maxLength', () => {
+      const result = truncateMessage('Short message', 50);
+      expect(result).toBe('Short message');
+    });
+
+    it('should truncate long messages with ellipsis', () => {
+      const longMessage = 'This is a very long message that should be truncated';
+      const result = truncateMessage(longMessage, 20);
+      expect(result.length).toBe(20);
+      expect(result.endsWith('...')).toBe(true);
+    });
+
+    it('should strip formatting before truncating', () => {
+      const result = truncateMessage('*Bold* message here', 50);
+      expect(result).toBe('Bold message here');
+      expect(result).not.toContain('*');
+    });
+
+    it('should replace newlines with spaces', () => {
+      const result = truncateMessage('Line 1\nLine 2', 50);
+      expect(result).toBe('Line 1 Line 2');
+      expect(result).not.toContain('\n');
+    });
+
+    it('should use default maxLength of 50', () => {
+      const longMessage = 'A'.repeat(100);
+      const result = truncateMessage(longMessage);
+      expect(result.length).toBe(50);
+    });
+
+    it('should handle empty string', () => {
+      expect(truncateMessage('')).toBe('');
+    });
+
+    it('should handle message exactly at maxLength', () => {
+      const message = 'A'.repeat(50);
+      const result = truncateMessage(message, 50);
+      expect(result).toBe(message);
+      expect(result.length).toBe(50);
+    });
+
+    it('should handle combined formatting and newlines before truncating', () => {
+      const result = truncateMessage('*Hello*\n*World*', 50);
+      expect(result).toBe('Hello World');
+    });
+
+    it('should truncate correctly at word boundaries not guaranteed', () => {
+      // Note: This implementation truncates at character boundary, not word boundary
+      const result = truncateMessage('The quick brown fox jumps', 15);
+      expect(result).toBe('The quick br...');
+    });
+  });
+});

--- a/src/app/shared/utils/message-format.helper.ts
+++ b/src/app/shared/utils/message-format.helper.ts
@@ -1,0 +1,46 @@
+/**
+ * Formats message content for display.
+ * Supports:
+ * - Line breaks (preserved)
+ * - Bold text (*word* → <strong>word</strong>)
+ *
+ * Security: HTML is escaped before formatting to prevent XSS.
+ */
+export function formatMessageContent(content: string): string {
+  // 1. Escape HTML entities first (security)
+  let formatted = escapeHtml(content);
+
+  // 2. Convert *bold* syntax to <strong> tags
+  // Matches *word* or *multiple words* but not * alone or **
+  formatted = formatted.replace(/\*([^*]+)\*/g, '<strong>$1</strong>');
+
+  // 3. Convert newlines to <br> tags
+  formatted = formatted.replace(/\n/g, '<br>');
+
+  return formatted;
+}
+
+/**
+ * Strips formatting from message content (for previews, notifications).
+ */
+export function stripMessageFormatting(content: string): string {
+  return content.replace(/\*([^*]+)\*/g, '$1');
+}
+
+function escapeHtml(text: string): string {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+/**
+ * Truncate message for preview display
+ */
+export function truncateMessage(content: string, maxLength: number = 50): string {
+  const stripped = stripMessageFormatting(content);
+  const singleLine = stripped.replace(/\n/g, ' ');
+  if (singleLine.length <= maxLength) {
+    return singleLine;
+  }
+  return singleLine.substring(0, maxLength - 3) + '...';
+}


### PR DESCRIPTION
## Summary

Implements a WhatsApp-style messaging feature for parents to communicate with each other.

- **WhatsApp-style split view layout**: Conversation list on left, selected chat on right
- **Conversation list**: Shows all conversations with unread badges, timestamps, and context icons
- **Message thread**: Chat bubbles with sender names and timestamps, aligned to bottom
- **Message input**: Enter to send, Shift+Enter for line break
- **Delayed mark-as-read**: Messages marked as read 2 seconds after viewing (cancellable)
- **Real backend integration**: Connected to `/conversations` API endpoints

### Components created
- `messages-page` - Main WhatsApp-style split view container
- `conversation-list` - List of conversations with selection
- `conversation-card` - Individual conversation item
- `conversation-header` - Header showing conversation context
- `conversation-detail-page` - Mobile full-page conversation view
- `message-thread` - Scrollable message container
- `message-bubble` - Individual message with sender and timestamp
- `message-input` - Text input with Enter-to-send

### Helper functions with tests
- `sortConversations` - Sort by most recent activity
- `getConversationDisplayInfo` - Get icon, title, subtitle for conversation context
- `formatMessageTimestamp` - Format timestamps (today, yesterday, date)
- `truncateMessage` - Truncate preview text with ellipsis

## Test plan

- [ ] Navigate to /messages when logged in
- [ ] Verify conversation list loads from API
- [ ] Click a conversation and verify messages load
- [ ] Send a message and verify it appears in the thread
- [ ] Verify unread badges clear after 2 seconds
- [ ] Test Enter to send and Shift+Enter for line break
- [ ] Test mobile view navigates to detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)